### PR TITLE
formatLocation: more helpful error messages

### DIFF
--- a/format/location.js
+++ b/format/location.js
@@ -7,7 +7,7 @@ const formatLocation = (profile, l, name = 'location') => {
 		if ('string' === typeof l.id) return profile.formatPoi(l)
 		if ('string' === typeof l.address) return profile.formatAddress(l)
 		if (!l.type) throw new Error(`missing ${name}.type`)
-		throw new Error(`invalid ${name}type: ${l.type}`)
+		throw new Error(`invalid ${name}.type: ${l.type}`)
 	}
 	throw new Error(name + ': valid station, address or poi required.')
 }

--- a/format/location.js
+++ b/format/location.js
@@ -1,14 +1,15 @@
 'use strict'
 
-const formatLocation = (profile, l) => {
+const formatLocation = (profile, l, name = 'location') => {
 	if ('string' === typeof l) return profile.formatStation(l)
 	if ('object' === typeof l && !Array.isArray(l)) {
 		if (l.type === 'station') return profile.formatStation(l.id)
 		if ('string' === typeof l.id) return profile.formatPoi(l)
 		if ('string' === typeof l.address) return profile.formatAddress(l)
-		throw new Error('invalid location type: ' + l.type)
+		if (!l.type) throw new Error(`missing ${name}.type`)
+		throw new Error(`invalid ${name}type: ${l.type}`)
 	}
-	throw new Error('valid station, address or poi required.')
+	throw new Error(name + ': valid station, address or poi required.')
 }
 
 module.exports = formatLocation

--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ const createClient = (profile, request = _request) => {
 	}
 
 	const journeys = (from, to, opt = {}) => {
-		from = profile.formatLocation(profile, from)
-		to = profile.formatLocation(profile, to)
+		from = profile.formatLocation(profile, from, 'from')
+		to = profile.formatLocation(profile, to, 'to')
 
 		if (('earlierThan' in opt) && ('laterThan' in opt)) {
 			throw new Error('opt.laterThan and opt.laterThan are mutually exclusive.')
@@ -94,7 +94,7 @@ const createClient = (profile, request = _request) => {
 			bike: false, // only bike-friendly journeys
 			tickets: false, // return tickets?
 		}, opt)
-		if (opt.via) opt.via = profile.formatLocation(profile, opt.via)
+		if (opt.via) opt.via = profile.formatLocation(profile, opt.via, 'opt.via')
 		opt.when = opt.when || new Date()
 
 		const filters = [


### PR DESCRIPTION
This makes the error message more intuitive for the following call. See also #44.

```js
client.journeys('12345', {duration: 10})
```

Before:

```
/Users/j/web/hafas-client/format/location.js:9
		throw new Error('invalid location type: ' + l.type)
		^

Error: invalid location type: undefined
    at Object.formatLocation (/Users/j/web/hafas-client/format/location.js:9:9)
    at Object.journeys (/Users/j/web/hafas-client/index.js:61:16)
    at Object.<anonymous> (/Users/j/web/hafas-client/p/vbb/example.js:11:8)
    at Module._compile (module.js:649:30)
    at Object.Module._extensions..js (module.js:660:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)
    at Function.Module.runMain (module.js:690:10)
    at startup (bootstrap_node.js:194:16)
```

With this PR:

```
/Users/j/web/hafas-client/format/location.js:9
		if (!l.type) throw new Error(`missing ${name}.type`)
		             ^

Error: missing to.type
    at Object.formatLocation (/Users/j/web/hafas-client/format/location.js:9:22)
    at Object.journeys (/Users/j/web/hafas-client/index.js:61:16)
    at Object.<anonymous> (/Users/j/web/hafas-client/p/vbb/example.js:11:8)
    at Module._compile (module.js:649:30)
    at Object.Module._extensions..js (module.js:660:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)
    at Function.Module.runMain (module.js:690:10)
    at startup (bootstrap_node.js:194:16)
```