### PR TITLE
journey leg polylines

### DIFF
--- a/docs/journey-leg.md
+++ b/docs/journey-leg.md
@@ -25,7 +25,8 @@ With `opt`, you can override the default options, which look like this:
 ```js
 {
 	when: new Date(),
-	passedStations: true // return stations on the way?
+	passedStations: true, // return stations on the way?
+	polyline: false // return a shape for the leg?
 }
 ```
 
@@ -116,3 +117,5 @@ The response looked like this:
 	passed: [ /* … */ ]
 }
 ```
+
+If you pass `polyline: true`, the leg will have a `polyline` field, containing an encoded shape. You can use e.g. [`@mapbox/polyline`](https://www.npmjs.com/package/@mapbox/polyline) to decode it.

--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -60,7 +60,8 @@ With `opt`, you can override the default options, which look like this:
 		express: true,
 		regional: true
 	},
-	tickets: false // return tickets? only available with some profiles
+	tickets: false, // return tickets? only available with some profiles
+	polylines: false // return a shape for each leg?
 }
 ```
 
@@ -277,3 +278,5 @@ client.journeys(hbf, heinrichHeineStr)
 departure of last journey 2017-12-17T19:07:00.000+01:00
 departure of first (later) journey 2017-12-17T19:19:00.000+01:00
 ```
+
+If you pass `polylines: true`, each journey leg will have a `polyline` field, containing an encoded shape. You can use e.g. [`@mapbox/polyline`](https://www.npmjs.com/package/@mapbox/polyline) to decode it.

--- a/index.js
+++ b/index.js
@@ -270,7 +270,8 @@ const createClient = (profile, request = _request) => {
 			throw new Error('lineName must be a non-empty string.')
 		}
 		opt = Object.assign({
-			passedStations: true // return stations on the way?
+			passedStations: true, // return stations on the way?
+			polyline: false
 		}, opt)
 		opt.when = opt.when || new Date()
 
@@ -280,11 +281,16 @@ const createClient = (profile, request = _request) => {
 			req: {
 				jid: ref,
 				name: lineName,
-				date: profile.formatDate(profile, opt.when)
+				date: profile.formatDate(profile, opt.when),
+				getPolyline: !!opt.polyline
 			}
 		})
 		.then((d) => {
-			const parse = profile.parseJourneyLeg(profile, d.locations, d.lines, d.remarks)
+			let polylines = []
+			if (opt.polyline && Array.isArray(d.common.polyL)) {
+				polylines = d.common.polyL.map(p => p.crdEncYX)
+			}
+			const parse = profile.parseJourneyLeg(profile, d.locations, d.lines, d.remarks, polylines)
 
 			const leg = { // pretend the leg is contained in a journey
 				type: 'JNY',

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ const createClient = (profile, request = _request) => {
 			accessibility: 'none', // 'none', 'partial' or 'complete'
 			bike: false, // only bike-friendly journeys
 			tickets: false, // return tickets?
+			polylines: false // return leg shapes?
 		}, opt)
 		if (opt.via) opt.via = profile.formatLocation(profile, opt.via)
 		opt.when = opt.when || new Date()
@@ -126,7 +127,7 @@ const createClient = (profile, request = _request) => {
 				getPT: true, // todo: what is this?
 				outFrwd: true, // todo: what is this?
 				getIV: false, // todo: walk & bike as alternatives?
-				getPolyline: false // todo: shape for displaying on a map?
+				getPolyline: !!opt.polylines
 			}
 			if (profile.journeysNumF) query.numF = opt.results
 

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ const createClient = (profile, request = _request) => {
 
 				let polylines = []
 				if (opt.polylines && Array.isArray(d.common.polyL)) {
-					polylines = d.common.polyL.map(p => p.crdEncYX)
+					polylines = d.common.polyL
 				}
 				const parse = profile.parseJourney(profile, d.locations, d.lines, d.remarks, polylines)
 
@@ -279,6 +279,7 @@ const createClient = (profile, request = _request) => {
 			cfg: {polyEnc: 'GPA'},
 			meth: 'JourneyDetails',
 			req: {
+				// todo: getTrainComposition
 				jid: ref,
 				name: lineName,
 				date: profile.formatDate(profile, opt.when),
@@ -288,7 +289,7 @@ const createClient = (profile, request = _request) => {
 		.then((d) => {
 			let polylines = []
 			if (opt.polyline && Array.isArray(d.common.polyL)) {
-				polylines = d.common.polyL.map(p => p.crdEncYX)
+				polylines = d.common.polyL
 			}
 			const parse = profile.parseJourneyLeg(profile, d.locations, d.lines, d.remarks, polylines)
 

--- a/index.js
+++ b/index.js
@@ -138,7 +138,13 @@ const createClient = (profile, request = _request) => {
 			})
 			.then((d) => {
 				if (!Array.isArray(d.outConL)) return []
-				const parse = profile.parseJourney(profile, d.locations, d.lines, d.remarks)
+
+				let polylines = []
+				if (opt.polylines && Array.isArray(d.common.polyL)) {
+					polylines = d.common.polyL.map(p => p.crdEncYX)
+				}
+				const parse = profile.parseJourney(profile, d.locations, d.lines, d.remarks, polylines)
+
 				if (!journeys.earlierRef) journeys.earlierRef = d.outCtxScrB
 
 				let latestDep = -Infinity

--- a/p/vbb/example.js
+++ b/p/vbb/example.js
@@ -13,6 +13,10 @@ client.journeys('900000003201', '900000024101', {results: 1, polylines: true})
 // client.nearby(52.5137344, 13.4744798, {distance: 60})
 // client.radar(52.52411, 13.41002, 52.51942, 13.41709, {results: 10})
 
+// .then(([journey]) => {
+// 	const leg = journey.legs[0]
+// 	return client.journeyLeg(leg.id, leg.line.name, {polyline: true})
+// })
 .then((data) => {
 	console.log(require('util').inspect(data, {depth: null}))
 })

--- a/p/vbb/example.js
+++ b/p/vbb/example.js
@@ -6,7 +6,7 @@ const vbbProfile = require('.')
 const client = createClient(vbbProfile)
 
 // Hauptbahnhof to Charlottenburg
-client.journeys('900000003201', '900000024101', {results: 1})
+client.journeys('900000003201', '900000024101', {results: 1, polylines: true})
 // client.departures('900000013102', {duration: 1})
 // client.locations('Alexanderplatz', {results: 2})
 // client.location('900000042101') // Spichernstr

--- a/p/vbb/index.js
+++ b/p/vbb/index.js
@@ -68,8 +68,8 @@ const parseLocation = (profile, l, lines) => {
 	return res
 }
 
-const createParseJourney = (profile, stations, lines, remarks) => {
-	const parseJourney = _createParseJourney(profile, stations, lines, remarks)
+const createParseJourney = (profile, stations, lines, remarks, polylines) => {
+	const parseJourney = _createParseJourney(profile, stations, lines, remarks, polylines)
 
 	const parseJourneyWithTickets = (j) => {
 		const res = parseJourney(j)

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -4,7 +4,7 @@ const parseDateTime = require('./date-time')
 
 const clone = obj => Object.assign({}, obj)
 
-const createParseJourneyLeg = (profile, stations, lines, remarks) => {
+const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => {
 	// todo: finish parse/remark.js first
 	const applyRemark = (j, rm) => {}
 
@@ -32,6 +32,12 @@ const createParseJourneyLeg = (profile, stations, lines, remarks) => {
 			const realtime = profile.parseDateTime(profile, j.date, pt.arr.aTimeR)
 			const planned = profile.parseDateTime(profile, j.date, pt.arr.aTimeS)
 			res.arrivalDelay = Math.round((realtime - planned) / 1000)
+		}
+
+		if (pt.jny && pt.jny.polyG) {
+			const p = pt.jny.polyG.polyXL
+			// todo: there can be >1 polyline
+			if (p && p.length > 0) res.polyline = polylines[p[0]] || null
 		}
 
 		if (pt.type === 'WALK') {

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -35,9 +35,10 @@ const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => 
 		}
 
 		if (pt.jny && pt.jny.polyG) {
-			const p = pt.jny.polyG.polyXL
+			let p = pt.jny.polyG.polyXL
+			p = p && polylines[p[0]]
 			// todo: there can be >1 polyline
-			if (p && p.length > 0) res.polyline = polylines[p[0]] || null
+			res.polyline = p && p.crdEncYX || null
 		}
 
 		if (pt.type === 'WALK') {

--- a/parse/journey.js
+++ b/parse/journey.js
@@ -2,8 +2,8 @@
 
 const clone = obj => Object.assign({}, obj)
 
-const createParseJourney = (profile, stations, lines, remarks) => {
-	const parseLeg = profile.parseJourneyLeg(profile, stations, lines, remarks)
+const createParseJourney = (profile, stations, lines, remarks, polylines) => {
+	const parseLeg = profile.parseJourneyLeg(profile, stations, lines, remarks, polylines)
 
 	// todo: c.sDays
 	// todo: c.dep.dProgType, c.arr.dProgType


### PR DESCRIPTION
- `journeys()` gets a `polylines` option.
- `journeyLeg()` gets a `polyline` option.
- If `true`, each journey leg will have a `polyline` field with an encoded shape.

I chose the default of `false`, because if we find out how to get the API *not* to compute polylines, we may be able to decrease the response time.