### PR TITLE
opt.when -> opt.departure/opt.arrival

### DIFF
--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -40,7 +40,10 @@ With `opt`, you can override the default options, which look like this:
 
 ```js
 {
-	when: new Date(),
+	// Use either `departure` or `arrival` to specify a date/time.
+	departure: new Date(),
+	arrival: null,
+
 	earlierThan: null, // ref to get journeys earlier than the last query
 	laterThan: null, // ref to get journeys later than the last query
 	results: 5, // how many journeys?

--- a/format/products-filter.js
+++ b/format/products-filter.js
@@ -16,12 +16,14 @@ const createFormatProductsFilter = (profile) => {
 		if (!isObj(filter)) throw new Error('products filter must be an object')
 		filter = Object.assign({}, defaultProducts, filter)
 
-		let res = 0
+		let res = 0, products = 0
 		for (let product in filter) {
 			if (!hasProp(filter, product) || filter[product] !== true) continue
 			if (!byProduct[product]) throw new Error('unknown product ' + product)
+			products++
 			for (let bitmask of byProduct[product].bitmasks) res += bitmask
 		}
+		if (products === 0) throw new Error('no products used')
 
 		return {
 			type: 'PROD',

--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ const createClient = (profile, request = _request) => {
 			if (!isNonEmptyString(opt.earlierThan)) {
 				throw new Error('opt.earlierThan must be a non-empty string.')
 			}
-			if ('when' in opt) {
-				throw new Error('opt.earlierThan and opt.when are mutually exclusive.')
+			if (('departure' in opt) || ('arrival' in opt)) {
+				throw new Error('opt.earlierThan and opt.departure/opt.arrival are mutually exclusive.')
 			}
 			journeysRef = opt.earlierThan
 		}
@@ -78,8 +78,8 @@ const createClient = (profile, request = _request) => {
 			if (!isNonEmptyString(opt.laterThan)) {
 				throw new Error('opt.laterThan must be a non-empty string.')
 			}
-			if ('when' in opt) {
-				throw new Error('opt.laterThan and opt.when are mutually exclusive.')
+			if (('departure' in opt) || ('arrival' in opt)) {
+				throw new Error('opt.laterThan and opt.departure/opt.arrival are mutually exclusive.')
 			}
 			journeysRef = opt.laterThan
 		}
@@ -97,8 +97,19 @@ const createClient = (profile, request = _request) => {
 			polylines: false // return leg shapes?
 		}, opt)
 		if (opt.via) opt.via = profile.formatLocation(profile, opt.via, 'opt.via')
-		opt.when = new Date(opt.when || Date.now())
-		if (Number.isNaN(+opt.when)) throw new Error('opt.when is invalid')
+
+		if (opt.when !== undefined) {
+			throw new Error('opt.when is not supported anymore. Use opt.departure/opt.arrival.')
+		}
+		let when = new Date(), outFrwd = true
+		if (opt.departure !== undefined && opt.departure !== null) {
+			when = new Date(opt.departure)
+			if (Number.isNaN(+when)) throw new Error('opt.departure is invalid')
+		} else if (opt.arrival !== undefined && opt.arrival !== null) {
+			when = new Date(opt.arrival)
+			if (Number.isNaN(+when)) throw new Error('opt.arrival is invalid')
+			outFrwd = false
+		}
 
 		const filters = [
 			profile.formatProductsFilter(opt.products || {})
@@ -132,10 +143,10 @@ const createClient = (profile, request = _request) => {
 				arrLocL: [to],
 				jnyFltrL: filters,
 				getTariff: !!opt.tickets,
+				outFrwd,
 
 				// todo: what is req.gisFltrL?
 				getPT: true, // todo: what is this?
-				outFrwd: true, // todo: what is this?
 				getIV: false, // todo: walk & bike as alternatives?
 				getPolyline: !!opt.polylines
 			}
@@ -172,7 +183,7 @@ const createClient = (profile, request = _request) => {
 			})
 		}
 
-		return more(opt.when, journeysRef)
+		return more(when, journeysRef)
 	}
 
 	const locations = (query, opt = {}) => {

--- a/test/db.js
+++ b/test/db.js
@@ -101,7 +101,7 @@ const regensburgHbf = '8000309'
 
 test('Berlin Jungfernheide to München Hbf', co(function* (t) {
 	const journeys = yield client.journeys(jungfernh, münchenHbf, {
-		when, passedStations: true
+		departure: when, passedStations: true
 	})
 
 	t.ok(Array.isArray(journeys))
@@ -144,7 +144,7 @@ test('Berlin Jungfernheide to Torfstraße 17', co(function* (t) {
 	const journeys = yield client.journeys(jungfernh, {
 		type: 'location', address: 'Torfstraße 17',
 		latitude: 52.5416823, longitude: 13.3491223
-	}, {when})
+	}, {departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.ok(journeys.length >= 1, 'no journeys')
@@ -173,7 +173,7 @@ test('Berlin Jungfernheide to ATZE Musiktheater', co(function* (t) {
 	const journeys = yield client.journeys(jungfernh, {
 		type: 'location', id: '991598902', name: 'ATZE Musiktheater',
 		latitude: 52.542417, longitude: 13.350437
-	}, {when})
+	}, {departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.ok(journeys.length >= 1, 'no journeys')
@@ -207,7 +207,7 @@ test('journeys: via works – with detour', co(function* (t) {
 	const [journey] = yield client.journeys(westhafen, wedding, {
 		via: württembergallee,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -228,7 +228,7 @@ test('journeys: via works – without detour', co(function* (t) {
 	const [journey] = yield client.journeys(ruhleben, zoo, {
 		via: kastanienallee,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -242,7 +242,7 @@ test('journeys: via works – without detour', co(function* (t) {
 
 test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 	const model = yield client.journeys(jungfernh, münchenHbf, {
-		results: 3, when
+		results: 3, departure: when
 	})
 
 	t.equal(typeof model.earlierRef, 'string')
@@ -253,12 +253,12 @@ test('earlier/later journeys, Jungfernheide -> München Hbf', co(function* (t) {
 	// when and earlierThan/laterThan should be mutually exclusive
 	t.throws(() => {
 		client.journeys(jungfernh, münchenHbf, {
-			when, earlierThan: model.earlierRef
+			departure: when, earlierThan: model.earlierRef
 		})
 	})
 	t.throws(() => {
 		client.journeys(jungfernh, münchenHbf, {
-			when, laterThan: model.laterRef
+			departure: when, laterThan: model.laterRef
 		})
 	})
 

--- a/test/insa.js
+++ b/test/insa.js
@@ -70,7 +70,7 @@ test('Magdeburg Hbf to Magdeburg-Buckau', co(function*(t) {
 	const magdeburgHbf = '8010224'
 	const magdeburgBuckau = '8013456'
 	const journeys = yield client.journeys(magdeburgHbf, magdeburgBuckau, {
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -110,7 +110,7 @@ test('Magdeburg Hbf to 39104 Magdeburg, Sternstr. 10', co(function*(t) {
 	}
 
 	const journeys = yield client.journeys(magdeburgHbf, sternStr, {
-		when
+		departure: when
 	})
 
 	t.ok(Array.isArray(journeys))
@@ -147,7 +147,7 @@ test('Kloster Unser Lieben Frauen to Magdeburg Hbf', co(function*(t) {
 	}
 	const magdeburgHbf = '8010224'
 	const journeys = yield client.journeys(kloster, magdeburgHbf, {
-		when
+		departure: when
 	})
 
 	t.ok(Array.isArray(journeys))
@@ -185,7 +185,7 @@ test('journeys: via works – with detour', co(function* (t) {
 	const [journey] = yield client.journeys(hasselbachplatzSternstrasse, stendal, {
 		via: dessau,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -208,7 +208,7 @@ test('journeys: via works – without detour', co(function* (t) {
 	const [journey] = yield client.journeys(hasselbachplatzSternstrasse, universitaet, {
 		via: breiterWeg,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -270,7 +270,7 @@ test('journey leg details', co(function* (t) {
 	const magdeburgHbf = '8010224'
 	const magdeburgBuckau = '8013456'
 	const [journey] = yield client.journeys(magdeburgHbf, magdeburgBuckau, {
-		results: 1, when
+		results: 1, departure: when
 	})
 
 	const p = journey.legs[0]

--- a/test/nahsh.js
+++ b/test/nahsh.js
@@ -99,7 +99,7 @@ const schleswig = '8005362'
 
 test('Kiel Hbf to Flensburg', co(function* (t) {
 	const journeys = yield client.journeys(kielHbf, flensburg, {
-		when, passedStations: true
+		departure: when, passedStations: true
 	})
 
 	t.ok(Array.isArray(journeys))
@@ -148,7 +148,7 @@ test('Kiel Hbf to Husum, Zingel 10', co(function* (t) {
 		address: 'Husum, Zingel 10'
 	}
 
-	const journeys = yield client.journeys(kielHbf, zingel, {when})
+	const journeys = yield client.journeys(kielHbf, zingel, {departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.ok(journeys.length >= 1, 'no journeys')
@@ -185,7 +185,7 @@ test('Holstentor to Kiel Hbf', co(function* (t) {
 		name: 'Hansestadt Lübeck, Holstentor (Denkmal)',
 		id: '970003547'
 	}
-	const journeys = yield client.journeys(holstentor, kielHbf, {when})
+	const journeys = yield client.journeys(holstentor, kielHbf, {departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.ok(journeys.length >= 1, 'no journeys')
@@ -219,7 +219,7 @@ test('Husum to Lübeck Hbf with stopover at Husum', co(function* (t) {
 	const [journey] = yield client.journeys(husum, luebeckHbf, {
 		via: kielHbf,
 		results: 1,
-		when
+		departure: when
 	})
 
 	const i1 = journey.legs.findIndex(leg => leg.destination.id === kielHbf)
@@ -234,7 +234,7 @@ test('Husum to Lübeck Hbf with stopover at Husum', co(function* (t) {
 
 test('earlier/later journeys, Kiel Hbf -> Flensburg', co(function* (t) {
 	const model = yield client.journeys(kielHbf, flensburg, {
-		results: 3, when
+		results: 3, departure: when
 	})
 
 	t.equal(typeof model.earlierRef, 'string')
@@ -245,12 +245,12 @@ test('earlier/later journeys, Kiel Hbf -> Flensburg', co(function* (t) {
 	// when and earlierThan/laterThan should be mutually exclusive
 	t.throws(() => {
 		client.journeys(kielHbf, flensburg, {
-			when, earlierThan: model.earlierRef
+			departure: when, earlierThan: model.earlierRef
 		})
 	})
 	t.throws(() => {
 		client.journeys(kielHbf, flensburg, {
-			when, laterThan: model.laterRef
+			departure: when, laterThan: model.laterRef
 		})
 	})
 
@@ -284,7 +284,7 @@ test('earlier/later journeys, Kiel Hbf -> Flensburg', co(function* (t) {
 
 test('leg details for Flensburg to Husum', co(function* (t) {
 	const journeys = yield client.journeys(flensburg, husum, {
-		results: 1, when
+		results: 1, departure: when
 	})
 
 	const p = journeys[0].legs[0]

--- a/test/nahsh.js
+++ b/test/nahsh.js
@@ -58,10 +58,9 @@ const assertIsKielHbf = (t, s) => {
 
 // todo: DRY with assertValidStationProducts
 // todo: DRY with other tests
-const assertValidProducts = (t, p) => {
-	for (let product of allProducts) {
-		product = product.product // wat
-		t.equal(typeof p[product], 'boolean', 'product ' + p + ' must be a boolean')
+const assertValidProducts = (t, products) => {
+	for (let p of allProducts) {
+		t.equal(typeof products[p.id], 'boolean', `product ${p.id} must be a boolean`)
 	}
 }
 

--- a/test/oebb.js
+++ b/test/oebb.js
@@ -120,7 +120,7 @@ const grazHbf = '8100173'
 
 test('Salzburg Hbf to Wien Westbahnhof', co(function* (t) {
 	const journeys = yield client.journeys(salzburgHbf, wienWestbahnhof, {
-		when, passedStations: true
+		departure: when, passedStations: true
 	})
 
 	t.ok(Array.isArray(journeys))
@@ -169,7 +169,7 @@ test('Salzburg Hbf to 1220 Wien, Wagramer Straße 5', co(function* (t) {
     	address: '1220 Wien, Wagramer Straße 5'
 	}
 
-	const journeys = yield client.journeys(salzburgHbf, wagramerStr, {when})
+	const journeys = yield client.journeys(salzburgHbf, wagramerStr, {departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.ok(journeys.length >= 1, 'no journeys')
@@ -206,7 +206,7 @@ test('Albertina to Salzburg Hbf', co(function* (t) {
     	name: 'Albertina',
     	id: '975900003'
 	}
-	const journeys = yield client.journeys(albertina, salzburgHbf, {when})
+	const journeys = yield client.journeys(albertina, salzburgHbf, {departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.ok(journeys.length >= 1, 'no journeys')
@@ -246,7 +246,7 @@ test('journeys: via works – with detour', co(function* (t) {
 	const [journey] = yield client.journeys(stephansplatz, schottenring, {
 		via: donauinsel,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -269,7 +269,7 @@ test('journeys: via works – without detour', co(function* (t) {
 	const [journey] = yield client.journeys(karlsplatz, praterstern, {
 		via: museumsquartier,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -283,7 +283,7 @@ test('journeys: via works – without detour', co(function* (t) {
 
 test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t) {
 	const model = yield client.journeys(salzburgHbf, wienWestbahnhof, {
-		results: 3, when
+		results: 3, departure: when
 	})
 
 	t.equal(typeof model.earlierRef, 'string')
@@ -294,12 +294,12 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 	// when and earlierThan/laterThan should be mutually exclusive
 	t.throws(() => {
 		client.journeys(salzburgHbf, wienWestbahnhof, {
-			when, earlierThan: model.earlierRef
+			departure: when, earlierThan: model.earlierRef
 		})
 	})
 	t.throws(() => {
 		client.journeys(salzburgHbf, wienWestbahnhof, {
-			when, laterThan: model.laterRef
+			departure: when, laterThan: model.laterRef
 		})
 	})
 
@@ -333,7 +333,7 @@ test('earlier/later journeys, Salzburg Hbf -> Wien Westbahnhof', co(function* (t
 
 test('leg details for Wien Westbahnhof to München Hbf', co(function* (t) {
 	const journeys = yield client.journeys(wienWestbahnhof, muenchenHbf, {
-		results: 1, when
+		results: 1, departure: when
 	})
 
 	const p = journeys[0].legs[0]

--- a/test/vbb.js
+++ b/test/vbb.js
@@ -60,7 +60,7 @@ const bismarckstr = '900000024201'
 
 test('journeys – station to station', co(function* (t) {
 	const journeys = yield client.journeys(spichernstr, amrumerStr, {
-		results: 3, when, passedStations: true
+		results: 3, departure: when, passedStations: true
 	})
 
 	t.ok(Array.isArray(journeys))
@@ -108,7 +108,7 @@ test('journeys – station to station', co(function* (t) {
 
 test('journeys – only subway', co(function* (t) {
 	const journeys = yield client.journeys(spichernstr, bismarckstr, {
-		results: 20, when,
+		results: 20, departure: when,
 		products: {
 			suburban: false,
 			subway:   true,
@@ -136,9 +136,10 @@ test('journeys – only subway', co(function* (t) {
 }))
 
 test('journeys – fails with no product', co(function* (t) {
+	t.plan(1)
 	try {
 		client.journeys(spichernstr, bismarckstr, {
-			when,
+			departure: when,
 			products: {
 				suburban: false,
 				subway:   false,
@@ -159,7 +160,7 @@ test('journeys – fails with no product', co(function* (t) {
 
 test('earlier/later journeys', co(function* (t) {
 	const model = yield client.journeys(spichernstr, bismarckstr, {
-		results: 3, when
+		results: 3, departure: when
 	})
 
 	t.equal(typeof model.earlierRef, 'string')
@@ -167,15 +168,25 @@ test('earlier/later journeys', co(function* (t) {
 	t.equal(typeof model.laterRef, 'string')
 	t.ok(model.laterRef)
 
-	// when and earlierThan/laterThan should be mutually exclusive
+	// departure/arrival and earlierThan/laterThan should be mutually exclusive
 	t.throws(() => {
 		client.journeys(spichernstr, bismarckstr, {
-			when, earlierThan: model.earlierRef
+			departure: when, earlierThan: model.earlierRef
 		})
 	})
 	t.throws(() => {
 		client.journeys(spichernstr, bismarckstr, {
-			when, laterThan: model.laterRef
+			departure: when, laterThan: model.laterRef
+		})
+	})
+	t.throws(() => {
+		client.journeys(spichernstr, bismarckstr, {
+			arrival: when, earlierThan: model.earlierRef
+		})
+	})
+	t.throws(() => {
+		client.journeys(spichernstr, bismarckstr, {
+			arrival: when, laterThan: model.laterRef
 		})
 	})
 
@@ -209,7 +220,7 @@ test('earlier/later journeys', co(function* (t) {
 
 test('journey leg details', co(function* (t) {
 	const journeys = yield client.journeys(spichernstr, amrumerStr, {
-		results: 1, when
+		results: 1, departure: when
 	})
 
 	const p = journeys[0].legs[0]
@@ -238,7 +249,7 @@ test('journeys – station to address', co(function* (t) {
 		type: 'location',
 		address: 'Torfstr. 17, Berlin',
 		latitude: 52.541797, longitude: 13.350042
-	}, {results: 1, when})
+	}, {results: 1, departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.strictEqual(journeys.length, 1)
@@ -267,7 +278,7 @@ test('journeys – station to POI', co(function* (t) {
 		id: '900980720',
 		name: 'Berlin, Atze Musiktheater für Kinder',
 		latitude: 52.543333, longitude: 13.351686
-	}, {results: 1, when})
+	}, {results: 1, departure: when})
 
 	t.ok(Array.isArray(journeys))
 	t.strictEqual(journeys.length, 1)
@@ -298,7 +309,7 @@ test('journeys: via works – with detour', co(function* (t) {
 	const [journey] = yield client.journeys(westhafen, wedding, {
 		via: württembergallee,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 
@@ -319,7 +330,7 @@ test('journeys: via works – without detour', co(function* (t) {
 	const [journey] = yield client.journeys(ruhleben, zoo, {
 		via: kastanienallee,
 		results: 1,
-		when,
+		departure: when,
 		passedStations: true
 	})
 


### PR DESCRIPTION
Allows one to query journeys *before* a certain timestamp.

This is a breaking change, because I removed `opt.when` completely for the sake of simplicity. It will now throw if `opt.when !== undefined`.