### PR TITLE
opt.passedStations -> opt.stopovers, leg.passed -> leg.stopovers

### DIFF
--- a/docs/journey-leg.md
+++ b/docs/journey-leg.md
@@ -114,7 +114,7 @@ The response looked like this:
 		}
 	},
 	direction: 'S Spandau',
-	passed: [ /* … */ ]
+	stopovers: [ /* … */ ]
 }
 ```
 

--- a/docs/journey-leg.md
+++ b/docs/journey-leg.md
@@ -25,7 +25,7 @@ With `opt`, you can override the default options, which look like this:
 ```js
 {
 	when: new Date(),
-	passedStations: true, // return stations on the way?
+	stopovers: true, // return stations on the way?
 	polyline: false // return a shape for the leg?
 }
 ```

--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -159,7 +159,7 @@ The response may look like this:
 				}
 			},
 			direction: 'S Potsdam Hauptbahnhof',
-			passed: [ {
+			stopovers: [ {
 				station: {
 					type: 'station',
 					id: '900000003201',

--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -48,7 +48,7 @@ With `opt`, you can override the default options, which look like this:
 	laterThan: null, // ref to get journeys later than the last query
 	results: 5, // how many journeys?
 	via: null, // let journeys pass this station
-	passedStations: false, // return stations on the way?
+	stopovers: false, // return stations on the way?
 	transfers: 5, // maximum of 5 transfers
 	transferTime: 0, // minimum time for a single transfer in minutes
 	accessibility: 'none', // 'none', 'partial' or 'complete'
@@ -83,7 +83,7 @@ const client = createClient(vbbProfile)
 // Hauptbahnhof to Heinrich-Heine-Str.
 client.journeys('900000003201', '900000100008', {
 	results: 1,
-	passedStations: true
+	stopovers: true
 })
 .then(console.log)
 .catch(console.error)

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ const createClient = (profile, request = _request) => {
 		opt = Object.assign({
 			results: 5, // how many journeys?
 			via: null, // let journeys pass this station?
-			passedStations: false, // return stations on the way?
+			stopovers: false, // return stations on the way?
 			transfers: 5, // maximum of 5 transfers
 			transferTime: 0, // minimum time for a single transfer in minutes
 			// todo: does this work with every endpoint?
@@ -138,7 +138,7 @@ const createClient = (profile, request = _request) => {
 				outDate: profile.formatDate(profile, when),
 				outTime: profile.formatTime(profile, when),
 				ctxScr: journeysRef,
-				getPasslist: !!opt.passedStations,
+				getPasslist: !!opt.stopovers,
 				maxChg: opt.transfers,
 				minChgTime: opt.transferTime,
 				depLocL: [from],
@@ -291,7 +291,7 @@ const createClient = (profile, request = _request) => {
 			throw new Error('lineName must be a non-empty string.')
 		}
 		opt = Object.assign({
-			passedStations: true, // return stations on the way?
+			stopovers: true, // return stations on the way?
 			polyline: false
 		}, opt)
 		opt.when = new Date(opt.when || Date.now())
@@ -318,7 +318,7 @@ const createClient = (profile, request = _request) => {
 				arr: maxBy(d.journey.stopL, 'idx'),
 				jny: d.journey
 			}
-			return parse(d.journey, leg, !!opt.passedStations)
+			return parse(d.journey, leg, !!opt.stopovers)
 		})
 	}
 

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -13,7 +13,9 @@ const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => 
 	// todo: what is pt.jny.dirFlg?
 	// todo: how does pt.freq work?
 	// todo: what is pt.himL?
-	const parseJourneyLeg = (j, pt, passed = true) => { // j = journey, pt = part
+
+	// j = journey, pt = part
+	const parseJourneyLeg = (j, pt, parseStopovers = true) => {
 		const dep = profile.parseDateTime(profile, j.date, pt.dep.dTimeR || pt.dep.dTimeS)
 		const arr = profile.parseDateTime(profile, j.date, pt.arr.aTimeR || pt.arr.aTimeS)
 		const res = {
@@ -56,7 +58,7 @@ const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => 
 			if (pt.dep.dPlatfS) res.departurePlatform = pt.dep.dPlatfS
 			if (pt.arr.aPlatfS) res.arrivalPlatform = pt.arr.aPlatfS
 
-			if (passed && pt.jny.stopL) {
+			if (parseStopovers && pt.jny.stopL) {
 				const parse = profile.parseStopover(profile, stations, lines, remarks, j.date)
 				const stopovers = pt.jny.stopL.map(parse)
 				// filter stations the train passes without stopping, as this doesn't comply with fptf (yet)

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -58,9 +58,9 @@ const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => 
 
 			if (passed && pt.jny.stopL) {
 				const parse = profile.parseStopover(profile, stations, lines, remarks, j.date)
-				const passedStations = pt.jny.stopL.map(parse)
+				const stopovers = pt.jny.stopL.map(parse)
 				// filter stations the train passes without stopping, as this doesn't comply with fptf (yet)
-				res.passed = passedStations.filter((x) => !x.passBy)
+				res.stopovers = stopovers.filter((x) => !x.passBy)
 			}
 			if (Array.isArray(pt.jny.remL)) {
 				for (let remark of pt.jny.remL) applyRemark(j, remark)

--- a/test/db.js
+++ b/test/db.js
@@ -76,7 +76,9 @@ const regensburgHbf = '8000309'
 
 test('journeys – Berlin Schwedter Str. to München Hbf', co(function* (t) {
 	const journeys = yield client.journeys(blnSchwedterStr, münchenHbf, {
-		results: 3, departure: when, passedStations: true
+		results: 3,
+		departure: when,
+		stopovers: true
 	})
 
 	yield testJourneysStationToStation({
@@ -160,7 +162,7 @@ test('journeys: via works – with detour', co(function* (t) {
 		via: württembergallee,
 		results: 1,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysWithDetour({

--- a/test/insa.js
+++ b/test/insa.js
@@ -44,7 +44,7 @@ test('journeys – Magdeburg Hbf to Magdeburg-Buckau', co(function* (t) {
 	const journeys = yield client.journeys(magdeburgHbf, magdeburgBuckau, {
 		results: 3,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysStationToStation({
@@ -125,7 +125,7 @@ test('journeys: via works – with detour', co(function* (t) {
 		via: dessau,
 		results: 1,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysWithDetour({

--- a/test/lib/journeys-with-detour.js
+++ b/test/lib/journeys-with-detour.js
@@ -11,8 +11,8 @@ const testJourneysWithDetour = co(function* (cfg) {
 	validate(t, journeys, 'journeys', 'journeys')
 
 	const leg = journeys[0].legs.some((leg) => {
-		return leg.passed && leg.passed.some((passed) => {
-			return detourIds.includes(passed.station.id)
+		return leg.stopovers && leg.stopovers.some((stopover) => {
+			return detourIds.includes(stopover.station.id)
 		})
 	})
 	t.ok(leg, detourIds.join('/') + ' is not being passed')

--- a/test/lib/validators.js
+++ b/test/lib/validators.js
@@ -171,12 +171,12 @@ const createValidateJourneyLeg = (cfg) => {
 			a.ok(leg.departurePlatform, name + '.departurePlatform must not be empty')
 		}
 
-		if ('passed' in leg) {
-			a.ok(Array.isArray(leg.passed), name + '.passed must be an array')
-			a.ok(leg.passed.length > 0, name + '.passed must not be empty')
+		if ('stopovers' in leg) {
+			a.ok(Array.isArray(leg.stopovers), name + '.stopovers must be an array')
+			a.ok(leg.stopovers.length > 0, name + '.stopovers must not be empty')
 
-			for (let i = 0; i < leg.passed.length; i++) {
-				val.stopover(val, leg.passed[i], name + `.passed[${i}]`)
+			for (let i = 0; i < leg.stopovers.length; i++) {
+				val.stopover(val, leg.stopovers[i], name + `.stopovers[${i}]`)
 			}
 		}
 

--- a/test/nahsh.js
+++ b/test/nahsh.js
@@ -69,7 +69,7 @@ test('journeys – Kiel Hbf to Flensburg', co(function* (t) {
 	const journeys = yield client.journeys(kielHbf, flensburg, {
 		results: 3,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysStationToStation({
@@ -153,7 +153,7 @@ test('Husum to Lübeck Hbf with stopover at Kiel Hbf', co(function* (t) {
 		via: kielHbf,
 		results: 1,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	validate(t, journeys, 'journeys', 'journeys')

--- a/test/nahsh.js
+++ b/test/nahsh.js
@@ -159,8 +159,8 @@ test('Husum to Lübeck Hbf with stopover at Kiel Hbf', co(function* (t) {
 	validate(t, journeys, 'journeys', 'journeys')
 
 	const leg = journeys[0].legs.some((leg) => {
-		return leg.passed && leg.passed.some((passed) => {
-			return passed.station.id === kielHbf
+		return leg.stopovers && leg.stopovers.some((stopover) => {
+			return stopover.station.id === kielHbf
 		})
 	})
 	t.ok(leg, 'Kiel Hbf is not being passed')

--- a/test/oebb.js
+++ b/test/oebb.js
@@ -62,7 +62,7 @@ test.skip('journeys – Salzburg Hbf to Wien Westbahnhof', co(function* (t) {
 	const journeys = yield client.journeys(salzburgHbf, wienFickeystr, {
 		results: 3,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysStationToStation({
@@ -150,7 +150,7 @@ test('journeys: via works – with detour', co(function* (t) {
 		via: donauinsel,
 		results: 1,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysWithDetour({
@@ -174,7 +174,7 @@ test('journeys: via works – without detour', co(function* (t) {
 		via: museumsquartier,
 		results: 1,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	validate(t, journeys, 'journeys', 'journeys')

--- a/test/oebb.js
+++ b/test/oebb.js
@@ -188,8 +188,8 @@ test('journeys: via works – without detour', co(function* (t) {
 	t.notOk(l1, 'transfer at Museumsquartier')
 
 	const l2 = journeys[0].legs.some((leg) => {
-		return leg.passed && leg.passed.some((passed) => {
-			return passed.station.id === museumsquartierPassed
+		return leg.stopovers && leg.stopovers.some((stopover) => {
+			return stopover.station.id === museumsquartierPassed
 		})
 	})
 	t.ok(l2, 'Museumsquartier is not being passed')

--- a/test/vbb.js
+++ b/test/vbb.js
@@ -113,7 +113,7 @@ test('journeys – Spichernstr. to Bismarckstr.', co(function* (t) {
 	const journeys = yield client.journeys(spichernstr, bismarckstr, {
 		results: 3,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysStationToStation({
@@ -252,7 +252,7 @@ test('journeys: via works – with detour', co(function* (t) {
 		via: württembergallee,
 		results: 1,
 		departure: when,
-		passedStations: true
+		stopovers: true
 	})
 
 	yield testJourneysWithDetour({


### PR DESCRIPTION
Aligns the phrasing with the rest of the codebase. Also brings `hafas-client` closer to [the proposed FPTF `stopover` type](https://github.com/public-transport/friendly-public-transport-format/pull/40).

This is a breaking change.