### PR TITLE
refactor parse functions to `parse(profile, opt, data)`

### DIFF
--- a/docs/writing-a-profile.md
+++ b/docs/writing-a-profile.md
@@ -37,8 +37,8 @@ Assuming the endpoint returns all lines names prefixed with `foo `, We can strip
 // get the default line parser
 const createParseLine = require('hafas-client/parse/line')
 
-const createParseLineWithoutFoo = (profile, data) => {
-	const parseLine = createParseLine(profile, data)
+const createParseLineWithoutFoo = (profile, opt, data) => {
+	const parseLine = createParseLine(profile, opt, data)
 
 	// wrapper function with additional logic
 	const parseLineWithoutFoo = (l) => {

--- a/docs/writing-a-profile.md
+++ b/docs/writing-a-profile.md
@@ -37,8 +37,8 @@ Assuming the endpoint returns all lines names prefixed with `foo `, We can strip
 // get the default line parser
 const createParseLine = require('hafas-client/parse/line')
 
-const createParseLineWithoutFoo = (profile, operators) => {
-	const parseLine = createParseLine(profile, operators)
+const createParseLineWithoutFoo = (profile, data) => {
+	const parseLine = createParseLine(profile, data)
 
 	// wrapper function with additional logic
 	const parseLineWithoutFoo = (l) => {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const createClient = (profile, request = _request) => {
 		const products = profile.formatProductsFilter(opt.products || {})
 
 		const dir = opt.direction ? profile.formatStation(opt.direction) : null
-		return request(profile, {
+		return request(profile, opt, {
 			meth: 'StationBoard',
 			req: {
 				type: 'DEP',
@@ -159,7 +159,7 @@ const createClient = (profile, request = _request) => {
 			}
 			if (profile.journeysNumF) query.numF = opt.results
 
-			return request(profile, {
+			return request(profile, opt, {
 				cfg: {polyEnc: 'GPA'},
 				meth: 'TripSearch',
 				req: profile.transformJourneysQuery(query, opt)
@@ -210,7 +210,7 @@ const createClient = (profile, request = _request) => {
 		}, opt)
 
 		const f = profile.formatLocationFilter(opt.stations, opt.addresses, opt.poi)
-		return request(profile, {
+		return request(profile, opt, {
 			cfg: {polyEnc: 'GPA'},
 			meth: 'LocMatch',
 			req: {input: {
@@ -234,7 +234,7 @@ const createClient = (profile, request = _request) => {
 		else if ('string' === typeof station) station = profile.formatStation(station)
 		else throw new Error('station must be an object or a string.')
 
-		return request(profile, {
+		return request(profile, opt, {
 			meth: 'LocDetails',
 			req: {
 				locL: [station]
@@ -267,7 +267,7 @@ const createClient = (profile, request = _request) => {
 			stations: true, // return stations?
 		}, opt)
 
-		return request(profile, {
+		return request(profile, opt, {
 			cfg: {polyEnc: 'GPA'},
 			meth: 'LocGeoPos',
 			req: {
@@ -305,7 +305,7 @@ const createClient = (profile, request = _request) => {
 		opt.when = new Date(opt.when || Date.now())
 		if (Number.isNaN(+opt.when)) throw new Error('opt.when is invalid')
 
-		return request(profile, {
+		return request(profile, opt, {
 			cfg: {polyEnc: 'GPA'},
 			meth: 'JourneyDetails',
 			req: {
@@ -353,7 +353,7 @@ const createClient = (profile, request = _request) => {
 		if (Number.isNaN(+opt.when)) throw new Error('opt.when is invalid')
 
 		const durationPerStep = opt.duration / Math.max(opt.frames, 1) * 1000
-		return request(profile, {
+		return request(profile, opt, {
 			meth: 'JourneyGeoPos',
 			req: {
 				maxJny: opt.results,

--- a/index.js
+++ b/index.js
@@ -51,7 +51,11 @@ const createClient = (profile, request = _request) => {
 		})
 		.then((d) => {
 			if (!Array.isArray(d.jnyL)) return [] // todo: throw err?
-			const parse = profile.parseDeparture(profile, d.locations, d.lines, d.remarks)
+			const parse = profile.parseDeparture(profile, {
+				locations: d.locations,
+				lines: d.lines,
+				remarks: d.remarks
+			})
 			return d.jnyL.map(parse)
 			.sort((a, b) => new Date(a.when) - new Date(b.when))
 		})
@@ -163,8 +167,12 @@ const createClient = (profile, request = _request) => {
 			.then((d) => {
 				if (!Array.isArray(d.outConL)) return []
 
-				const polylines = opt.polylines && d.common.polyL || []
-				const parse = profile.parseJourney(profile, d.locations, d.lines, d.remarks, polylines)
+				const parse = profile.parseJourney(profile, {
+					locations: d.locations,
+					lines: d.lines,
+					remarks: d.remarks,
+					polylines: opt.polylines && d.common.polyL || []
+				})
 
 				if (!journeys.earlierRef) journeys.earlierRef = d.outCtxScrB
 
@@ -217,7 +225,7 @@ const createClient = (profile, request = _request) => {
 		.then((d) => {
 			if (!d.match || !Array.isArray(d.match.locL)) return []
 			const parse = profile.parseLocation
-			return d.match.locL.map(loc => parse(profile, loc, d.lines))
+			return d.match.locL.map(loc => parse(profile, {lines: d.lines}, loc))
 		})
 	}
 
@@ -237,7 +245,7 @@ const createClient = (profile, request = _request) => {
 				// todo: proper stack trace?
 				throw new Error('invalid response')
 			}
-			return profile.parseLocation(profile, d.locL[0], d.lines)
+			return profile.parseLocation(profile, {lines: d.lines}, d.locL[0])
 		})
 	}
 
@@ -309,8 +317,12 @@ const createClient = (profile, request = _request) => {
 			}
 		})
 		.then((d) => {
-			const polylines = opt.polyline && d.common.polyL || []
-			const parse = profile.parseJourneyLeg(profile, d.locations, d.lines, d.remarks, polylines)
+			const parse = profile.parseJourneyLeg(profile, {
+				locations: d.locations,
+				lines: d.lines,
+				remarks: d.remarks,
+				polylines: opt.polyline && d.common.polyL || []
+			})
 
 			const leg = { // pretend the leg is contained in a journey
 				type: 'JNY',
@@ -362,8 +374,12 @@ const createClient = (profile, request = _request) => {
 		.then((d) => {
 			if (!Array.isArray(d.jnyL)) return []
 
-			const polylines = opt.polyline && d.common.polyL || []
-			const parse = profile.parseMovement(profile, d.locations, d.lines, d.remarks, polylines)
+			const parse = profile.parseMovement(profile, {
+				locations: d.locations,
+				lines: d.lines,
+				remarks: d.remarks,
+				polylines: opt.polyline && d.common.polyL || []
+			})
 			return d.jnyL.map(parse)
 		})
 	}

--- a/index.js
+++ b/index.js
@@ -234,6 +234,7 @@ const createClient = (profile, request = _request) => {
 		else if ('string' === typeof station) station = profile.formatStation(station)
 		else throw new Error('station must be an object or a string.')
 
+		const opt = {}
 		return request(profile, opt, {
 			meth: 'LocDetails',
 			req: {
@@ -287,7 +288,7 @@ const createClient = (profile, request = _request) => {
 		.then((d) => {
 			if (!Array.isArray(d.locL)) return []
 			const parse = profile.parseNearby
-			return d.locL.map(loc => parse(profile, opt, loc))
+			return d.locL.map(loc => parse(profile, opt, d, loc))
 		})
 	}
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ const createClient = (profile, request = _request) => {
 		})
 		.then((d) => {
 			if (!Array.isArray(d.jnyL)) return [] // todo: throw err?
-			const parse = profile.parseDeparture(profile, {
+			const parse = profile.parseDeparture(profile, opt, {
 				locations: d.locations,
 				lines: d.lines,
 				remarks: d.remarks
@@ -167,7 +167,7 @@ const createClient = (profile, request = _request) => {
 			.then((d) => {
 				if (!Array.isArray(d.outConL)) return []
 
-				const parse = profile.parseJourney(profile, {
+				const parse = profile.parseJourney(profile, opt, {
 					locations: d.locations,
 					lines: d.lines,
 					remarks: d.remarks,
@@ -225,7 +225,7 @@ const createClient = (profile, request = _request) => {
 		.then((d) => {
 			if (!d.match || !Array.isArray(d.match.locL)) return []
 			const parse = profile.parseLocation
-			return d.match.locL.map(loc => parse(profile, {lines: d.lines}, loc))
+			return d.match.locL.map(loc => parse(profile, opt, {lines: d.lines}, loc))
 		})
 	}
 
@@ -245,7 +245,7 @@ const createClient = (profile, request = _request) => {
 				// todo: proper stack trace?
 				throw new Error('invalid response')
 			}
-			return profile.parseLocation(profile, {lines: d.lines}, d.locL[0])
+			return profile.parseLocation(profile, opt, {lines: d.lines}, d.locL[0])
 		})
 	}
 
@@ -287,7 +287,7 @@ const createClient = (profile, request = _request) => {
 		.then((d) => {
 			if (!Array.isArray(d.locL)) return []
 			const parse = profile.parseNearby
-			return d.locL.map(loc => parse(profile, loc))
+			return d.locL.map(loc => parse(profile, opt, loc))
 		})
 	}
 
@@ -317,7 +317,7 @@ const createClient = (profile, request = _request) => {
 			}
 		})
 		.then((d) => {
-			const parse = profile.parseJourneyLeg(profile, {
+			const parse = profile.parseJourneyLeg(profile, opt, {
 				locations: d.locations,
 				lines: d.lines,
 				remarks: d.remarks,
@@ -374,7 +374,7 @@ const createClient = (profile, request = _request) => {
 		.then((d) => {
 			if (!Array.isArray(d.jnyL)) return []
 
-			const parse = profile.parseMovement(profile, {
+			const parse = profile.parseMovement(profile, opt, {
 				locations: d.locations,
 				lines: d.lines,
 				remarks: d.remarks,

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,7 +11,7 @@ const {fetch} = require('fetch-ponyfill')({Promise})
 
 const md5 = input => createHash('md5').update(input).digest()
 
-const request = (profile, data) => {
+const request = (profile, opt, data) => {
 	const body = profile.transformReqBody({lang: 'en', svcReqL: [data]})
 	const req = profile.transformReq({
 		method: 'post',

--- a/lib/request.js
+++ b/lib/request.js
@@ -88,11 +88,13 @@ const request = (profile, data) => {
 			d.operators = c.opL.map(op => profile.parseOperator(profile, op))
 		}
 		if (Array.isArray(c.prodL)) {
-			const parse = profile.parseLine(profile, d.operators)
+			const parse = profile.parseLine(profile, {
+				operators: d.operators
+			})
 			d.lines = c.prodL.map(parse)
 		}
 		if (Array.isArray(c.locL)) {
-			const parse = loc => profile.parseLocation(profile, loc, d.lines)
+			const parse = loc => profile.parseLocation(profile, {lines: d.lines}, loc)
 			d.locations = c.locL.map(parse)
 		}
 		return d

--- a/lib/request.js
+++ b/lib/request.js
@@ -88,13 +88,13 @@ const request = (profile, opt, data) => {
 			d.operators = c.opL.map(op => profile.parseOperator(profile, op))
 		}
 		if (Array.isArray(c.prodL)) {
-			const parse = profile.parseLine(profile, {
+			const parse = profile.parseLine(profile, opt, {
 				operators: d.operators
 			})
 			d.lines = c.prodL.map(parse)
 		}
 		if (Array.isArray(c.locL)) {
-			const parse = loc => profile.parseLocation(profile, {lines: d.lines}, loc)
+			const parse = loc => profile.parseLocation(profile, opt, {lines: d.lines}, loc)
 			d.locations = c.locL.map(parse)
 		}
 		return d

--- a/p/db/index.js
+++ b/p/db/index.js
@@ -34,8 +34,8 @@ const transformJourneysQuery = (query, opt) => {
 	return query
 }
 
-const createParseJourney = (profile, stations, lines, remarks, polylines) => {
-	const parseJourney = _createParseJourney(profile, stations, lines, remarks, polylines)
+const createParseJourney = (profile, data) => {
+	const parseJourney = _createParseJourney(profile, data)
 
 	// todo: j.sotRating, j.conSubscr, j.isSotCon, j.showARSLink, k.sotCtxt
 	// todo: j.conSubscr, j.showARSLink, j.useableTime

--- a/p/db/index.js
+++ b/p/db/index.js
@@ -34,8 +34,8 @@ const transformJourneysQuery = (query, opt) => {
 	return query
 }
 
-const createParseJourney = (profile, data) => {
-	const parseJourney = _createParseJourney(profile, data)
+const createParseJourney = (profile, opt, data) => {
+	const parseJourney = _createParseJourney(profile, opt, data)
 
 	// todo: j.sotRating, j.conSubscr, j.isSotCon, j.showARSLink, k.sotCtxt
 	// todo: j.conSubscr, j.showARSLink, j.useableTime

--- a/p/nahsh/index.js
+++ b/p/nahsh/index.js
@@ -78,8 +78,8 @@ const createParseJourney = (profile, opt, data) => {
 	return parseJourneyWithTickets
 }
 
-const createParseMovement = (profile, data) => {
-	const _parseMovement = _createParseMovement(profile, data)
+const createParseMovement = (profile, opt, data) => {
+	const _parseMovement = _createParseMovement(profile, opt, data)
 	const parseMovement = (m) => {
 		const res = _parseMovement(m)
 		// filter out empty nextStops entries

--- a/p/nahsh/index.js
+++ b/p/nahsh/index.js
@@ -21,8 +21,8 @@ const transformReqBody = (body) => {
 	return body
 }
 
-const parseLocation = (profile, l, lines) => {
-	const res = _parseLocation(profile, l, lines)
+const parseLocation = (profile, data, l) => {
+	const res = _parseLocation(profile, data, l)
 	// weird fix for empty lines, e.g. IC/EC at Flensburg Hbf
 	if (res.lines) {
 		res.lines = res.lines.filter(x => x.id && x.name)
@@ -36,8 +36,8 @@ const parseLocation = (profile, l, lines) => {
 	return res
 }
 
-const createParseJourney = (profile, stations, lines, remarks) => {
-	const parseJourney = _createParseJourney(profile, stations, lines, remarks)
+const createParseJourney = (profile, data) => {
+	const parseJourney = _createParseJourney(profile, data)
 
 	const parseJourneyWithTickets = (j) => {
 		const res = parseJourney(j)
@@ -78,8 +78,8 @@ const createParseJourney = (profile, stations, lines, remarks) => {
 	return parseJourneyWithTickets
 }
 
-const createParseMovement = (profile, locations, lines, remarks) => {
-	const _parseMovement = _createParseMovement(profile, locations, lines, remarks)
+const createParseMovement = (profile, data) => {
+	const _parseMovement = _createParseMovement(profile, data)
 	const parseMovement = (m) => {
 		const res = _parseMovement(m)
 		// filter out empty nextStops entries

--- a/p/nahsh/index.js
+++ b/p/nahsh/index.js
@@ -21,8 +21,8 @@ const transformReqBody = (body) => {
 	return body
 }
 
-const parseLocation = (profile, data, l) => {
-	const res = _parseLocation(profile, data, l)
+const parseLocation = (profile, opt, data, l) => {
+	const res = _parseLocation(profile, opt, data, l)
 	// weird fix for empty lines, e.g. IC/EC at Flensburg Hbf
 	if (res.lines) {
 		res.lines = res.lines.filter(x => x.id && x.name)
@@ -36,8 +36,8 @@ const parseLocation = (profile, data, l) => {
 	return res
 }
 
-const createParseJourney = (profile, data) => {
-	const parseJourney = _createParseJourney(profile, data)
+const createParseJourney = (profile, opt, data) => {
+	const parseJourney = _createParseJourney(profile, opt, data)
 
 	const parseJourneyWithTickets = (j) => {
 		const res = parseJourney(j)

--- a/p/oebb/index.js
+++ b/p/oebb/index.js
@@ -44,8 +44,8 @@ const parseLocation = (profile, opt, data, l) => {
 	return res
 }
 
-const createParseMovement = (profile, data) => {
-	const _parseMovement = _createParseMovement(profile, data)
+const createParseMovement = (profile, opt, data) => {
+	const _parseMovement = _createParseMovement(profile, opt, data)
 	const parseMovement = (m) => {
 		const res = _parseMovement(m)
 		// filter out POIs

--- a/p/oebb/index.js
+++ b/p/oebb/index.js
@@ -25,10 +25,10 @@ const transformReqBody = (body) => {
 	return body
 }
 
-const parseLocation = (profile, l, lines) => {
+const parseLocation = (profile, data, l) => {
 	// ÖBB has some 'stations' **in austria** with no departures/products,
 	// like station entrances, that are actually POIs.
-	const res = _parseLocation(profile, l, lines)
+	const res = _parseLocation(profile, data, l)
 	if (
 		res.type === 'station' &&
 		!res.products &&
@@ -44,8 +44,8 @@ const parseLocation = (profile, l, lines) => {
 	return res
 }
 
-const createParseMovement = (profile, locations, lines, remarks) => {
-	const _parseMovement = _createParseMovement(profile, locations, lines, remarks)
+const createParseMovement = (profile, data) => {
+	const _parseMovement = _createParseMovement(profile, data)
 	const parseMovement = (m) => {
 		const res = _parseMovement(m)
 		// filter out POIs

--- a/p/oebb/index.js
+++ b/p/oebb/index.js
@@ -25,10 +25,10 @@ const transformReqBody = (body) => {
 	return body
 }
 
-const parseLocation = (profile, data, l) => {
+const parseLocation = (profile, opt, data, l) => {
 	// ÖBB has some 'stations' **in austria** with no departures/products,
 	// like station entrances, that are actually POIs.
-	const res = _parseLocation(profile, data, l)
+	const res = _parseLocation(profile, opt, data, l)
 	if (
 		res.type === 'station' &&
 		!res.products &&

--- a/p/vbb/index.js
+++ b/p/vbb/index.js
@@ -23,8 +23,8 @@ const transformReqBody = (body) => {
 	return body
 }
 
-const createParseLine = (profile, operators) => {
-	const parseLine = _createParseLine(profile, operators)
+const createParseLine = (profile, data) => {
+	const parseLine = _createParseLine(profile, data)
 
 	const parseLineWithMoreDetails = (l) => {
 		const res = parseLine(l)
@@ -42,8 +42,8 @@ const createParseLine = (profile, operators) => {
 	return parseLineWithMoreDetails
 }
 
-const parseLocation = (profile, l, lines) => {
-	const res = _parseLocation(profile, l, lines)
+const parseLocation = (profile, data, l) => {
+	const res = _parseLocation(profile, data, l)
 
 	if (res.type === 'station') {
 		res.name = shorten(res.name)
@@ -56,8 +56,8 @@ const parseLocation = (profile, l, lines) => {
 	return res
 }
 
-const createParseJourney = (profile, stations, lines, remarks, polylines) => {
-	const parseJourney = _createParseJourney(profile, stations, lines, remarks, polylines)
+const createParseJourney = (profile, data) => {
+	const parseJourney = _createParseJourney(profile, data)
 
 	const parseJourneyWithTickets = (j) => {
 		const res = parseJourney(j)
@@ -86,8 +86,8 @@ const createParseJourney = (profile, stations, lines, remarks, polylines) => {
 	return parseJourneyWithTickets
 }
 
-const createParseDeparture = (profile, stations, lines, remarks) => {
-	const parseDeparture = _createParseDeparture(profile, stations, lines, remarks)
+const createParseDeparture = (profile, data) => {
+	const parseDeparture = _createParseDeparture(profile, data)
 
 	const ringbahnClockwise = /^ringbahn s\s?41$/i
 	const ringbahnAnticlockwise = /^ringbahn s\s?42$/i

--- a/p/vbb/index.js
+++ b/p/vbb/index.js
@@ -23,8 +23,8 @@ const transformReqBody = (body) => {
 	return body
 }
 
-const createParseLine = (profile, data) => {
-	const parseLine = _createParseLine(profile, data)
+const createParseLine = (profile, opt, data) => {
+	const parseLine = _createParseLine(profile, opt, data)
 
 	const parseLineWithMoreDetails = (l) => {
 		const res = parseLine(l)
@@ -42,8 +42,8 @@ const createParseLine = (profile, data) => {
 	return parseLineWithMoreDetails
 }
 
-const parseLocation = (profile, data, l) => {
-	const res = _parseLocation(profile, data, l)
+const parseLocation = (profile, opt, data, l) => {
+	const res = _parseLocation(profile, opt, data, l)
 
 	if (res.type === 'station') {
 		res.name = shorten(res.name)
@@ -56,8 +56,8 @@ const parseLocation = (profile, data, l) => {
 	return res
 }
 
-const createParseJourney = (profile, data) => {
-	const parseJourney = _createParseJourney(profile, data)
+const createParseJourney = (profile, opt, data) => {
+	const parseJourney = _createParseJourney(profile, opt, data)
 
 	const parseJourneyWithTickets = (j) => {
 		const res = parseJourney(j)
@@ -86,8 +86,8 @@ const createParseJourney = (profile, data) => {
 	return parseJourneyWithTickets
 }
 
-const createParseDeparture = (profile, data) => {
-	const parseDeparture = _createParseDeparture(profile, data)
+const createParseDeparture = (profile, opt, data) => {
+	const parseDeparture = _createParseDeparture(profile, opt, data)
 
 	const ringbahnClockwise = /^ringbahn s\s?41$/i
 	const ringbahnAnticlockwise = /^ringbahn s\s?42$/i

--- a/parse/departure.js
+++ b/parse/departure.js
@@ -6,7 +6,7 @@
 // todo: d.stbStop.dProgType
 // todo: d.freq, d.freq.jnyL, see https://github.com/public-transport/hafas-client/blob/9203ed1481f08baacca41ac5e3c19bf022f01b0b/parse.js#L115
 
-const createParseDeparture = (profile, {stations, lines, remarks}) => {
+const createParseDeparture = (profile, opt, {stations, lines, remarks}) => {
 	const findRemark = rm => remarks[parseInt(rm.remX)] || null
 
 	const parseDeparture = (d) => {

--- a/parse/departure.js
+++ b/parse/departure.js
@@ -6,7 +6,7 @@
 // todo: d.stbStop.dProgType
 // todo: d.freq, d.freq.jnyL, see https://github.com/public-transport/hafas-client/blob/9203ed1481f08baacca41ac5e3c19bf022f01b0b/parse.js#L115
 
-const createParseDeparture = (profile, stations, lines, remarks) => {
+const createParseDeparture = (profile, {stations, lines, remarks}) => {
 	const findRemark = rm => remarks[parseInt(rm.remX)] || null
 
 	const parseDeparture = (d) => {

--- a/parse/departure.js
+++ b/parse/departure.js
@@ -6,14 +6,14 @@
 // todo: d.stbStop.dProgType
 // todo: d.freq, d.freq.jnyL, see https://github.com/public-transport/hafas-client/blob/9203ed1481f08baacca41ac5e3c19bf022f01b0b/parse.js#L115
 
-const createParseDeparture = (profile, opt, {stations, lines, remarks}) => {
+const createParseDeparture = (profile, opt, {locations, lines, remarks}) => {
 	const findRemark = rm => remarks[parseInt(rm.remX)] || null
 
 	const parseDeparture = (d) => {
 		const when = profile.parseDateTime(profile, d.date, d.stbStop.dTimeR || d.stbStop.dTimeS)
 		const res = {
 			journeyId: d.jid,
-			station: stations[parseInt(d.stbStop.locX)] || null,
+			station: locations[parseInt(d.stbStop.locX)] || null,
 			when: when.toISO(),
 			direction: profile.parseStationName(d.dirTxt),
 			line: lines[parseInt(d.prodX)] || null,

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -42,7 +42,7 @@ const createParseJourneyLeg = (profile, data) => {
 			let p = pt.jny.polyG.polyXL
 			p = Array.isArray(p) && polylines[p[0]]
 			// todo: there can be >1 polyline
-			const parse = profile.parsePolyline(data)
+			const parse = profile.parsePolyline(profile, data)
 			res.polyline = p && parse(p) || null
 		}
 

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -4,7 +4,9 @@ const parseDateTime = require('./date-time')
 
 const clone = obj => Object.assign({}, obj)
 
-const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => {
+const createParseJourneyLeg = (profile, data) => {
+	const {locations, lines, remarks, polylines} = data
+
 	// todo: finish parse/remark.js first
 	const applyRemark = (j, rm) => {}
 
@@ -17,8 +19,8 @@ const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => 
 		const dep = profile.parseDateTime(profile, j.date, pt.dep.dTimeR || pt.dep.dTimeS)
 		const arr = profile.parseDateTime(profile, j.date, pt.arr.aTimeR || pt.arr.aTimeS)
 		const res = {
-			origin: clone(stations[parseInt(pt.dep.locX)]) || null,
-			destination: clone(stations[parseInt(pt.arr.locX)]),
+			origin: clone(locations[parseInt(pt.dep.locX)]) || null,
+			destination: clone(locations[parseInt(pt.arr.locX)]),
 			departure: dep.toISO(),
 			arrival: arr.toISO()
 		}
@@ -40,7 +42,7 @@ const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => 
 			let p = pt.jny.polyG.polyXL
 			p = Array.isArray(p) && polylines[p[0]]
 			// todo: there can be >1 polyline
-			const parse = profile.parsePolyline(stations)
+			const parse = profile.parsePolyline(data)
 			res.polyline = p && parse(p) || null
 		}
 
@@ -57,7 +59,7 @@ const createParseJourneyLeg = (profile, stations, lines, remarks, polylines) => 
 			if (pt.arr.aPlatfS) res.arrivalPlatform = pt.arr.aPlatfS
 
 			if (passed && pt.jny.stopL) {
-				const parse = profile.parseStopover(profile, stations, lines, remarks, j.date)
+				const parse = profile.parseStopover(profile, data, j.date)
 				const passedStations = pt.jny.stopL.map(parse)
 				// filter stations the train passes without stopping, as this doesn't comply with fptf (yet)
 				res.passed = passedStations.filter((x) => !x.passBy)

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -4,7 +4,7 @@ const parseDateTime = require('./date-time')
 
 const clone = obj => Object.assign({}, obj)
 
-const createParseJourneyLeg = (profile, data) => {
+const createParseJourneyLeg = (profile, opt, data) => {
 	const {locations, lines, remarks, polylines} = data
 
 	// todo: finish parse/remark.js first
@@ -42,7 +42,7 @@ const createParseJourneyLeg = (profile, data) => {
 			let p = pt.jny.polyG.polyXL
 			p = Array.isArray(p) && polylines[p[0]]
 			// todo: there can be >1 polyline
-			const parse = profile.parsePolyline(profile, data)
+			const parse = profile.parsePolyline(profile, opt, data)
 			res.polyline = p && parse(p) || null
 		}
 
@@ -59,7 +59,7 @@ const createParseJourneyLeg = (profile, data) => {
 			if (pt.arr.aPlatfS) res.arrivalPlatform = pt.arr.aPlatfS
 
 			if (passed && pt.jny.stopL) {
-				const parse = profile.parseStopover(profile, data, j.date)
+				const parse = profile.parseStopover(profile, opt, data, j.date)
 				const passedStations = pt.jny.stopL.map(parse)
 				// filter stations the train passes without stopping, as this doesn't comply with fptf (yet)
 				res.passed = passedStations.filter((x) => !x.passBy)

--- a/parse/journey.js
+++ b/parse/journey.js
@@ -2,8 +2,8 @@
 
 const clone = obj => Object.assign({}, obj)
 
-const createParseJourney = (profile, data) => {
-	const parseLeg = profile.parseJourneyLeg(profile, data)
+const createParseJourney = (profile, opt, data) => {
+	const parseLeg = profile.parseJourneyLeg(profile, opt, data)
 
 	// todo: c.sDays
 	// todo: c.conSubscr

--- a/parse/journey.js
+++ b/parse/journey.js
@@ -2,8 +2,8 @@
 
 const clone = obj => Object.assign({}, obj)
 
-const createParseJourney = (profile, stations, lines, remarks, polylines) => {
-	const parseLeg = profile.parseJourneyLeg(profile, stations, lines, remarks, polylines)
+const createParseJourney = (profile, data) => {
+	const parseLeg = profile.parseJourneyLeg(profile, data)
 
 	// todo: c.sDays
 	// todo: c.conSubscr

--- a/parse/line.js
+++ b/parse/line.js
@@ -2,7 +2,7 @@
 
 const slugg = require('slugg')
 
-const createParseLine = (profile, operators) => {
+const createParseLine = (profile, {operators}) => {
 	const byBitmask = []
 	for (let product of profile.products) {
 		for (let bitmask of product.bitmasks) {

--- a/parse/line.js
+++ b/parse/line.js
@@ -2,7 +2,7 @@
 
 const slugg = require('slugg')
 
-const createParseLine = (profile, {operators}) => {
+const createParseLine = (profile, opt, {operators}) => {
 	const byBitmask = []
 	for (let product of profile.products) {
 		for (let bitmask of product.bitmasks) {

--- a/parse/location.js
+++ b/parse/location.js
@@ -7,8 +7,8 @@ const ADDRESS = 'A'
 // todo: what is s.rRefL?
 // todo: is passing in profile necessary?
 
-// todo: [breaking] change to createParseLocation(profile, lines) => (l) => loc
-const parseLocation = (profile, l, lines) => {
+// todo: [breaking] change to createParseLocation(profile, data) => (l) => loc
+const parseLocation = (profile, {lines}, l) => {
 	const res = {type: 'location'}
 	if (l.crd) {
 		res.latitude = l.crd.y / 1000000

--- a/parse/location.js
+++ b/parse/location.js
@@ -7,8 +7,8 @@ const ADDRESS = 'A'
 // todo: what is s.rRefL?
 // todo: is passing in profile necessary?
 
-// todo: [breaking] change to createParseLocation(profile, data) => (l) => loc
-const parseLocation = (profile, {lines}, l) => {
+// todo: [breaking] change to createParseLocation(profile, opt, data) => (l) => loc
+const parseLocation = (profile, opt, {lines}, l) => {
 	const res = {type: 'location'}
 	if (l.crd) {
 		res.latitude = l.crd.y / 1000000

--- a/parse/movement.js
+++ b/parse/movement.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const createParseMovement = (profile, locations, lines, remarks, polylines = []) => {
+const createParseMovement = (profile, data) => {
+	const {locations, lines, remarks, polylines} = data
+
 	// todo: what is m.dirGeo? maybe the speed?
 	// todo: what is m.stopL?
 	// todo: what is m.proc? wut?
@@ -8,7 +10,7 @@ const createParseMovement = (profile, locations, lines, remarks, polylines = [])
 	// todo: what is m.ani.dirGeo[n]? maybe the speed?
 	// todo: what is m.ani.proc[n]? wut?
 	const parseMovement = (m) => {
-		const pStopover = profile.parseStopover(profile, locations, lines, remarks, m.date)
+		const pStopover = profile.parseStopover(profile, data, m.date)
 
 		const res = {
 			direction: profile.parseStationName(m.dirTxt),
@@ -36,13 +38,13 @@ const createParseMovement = (profile, locations, lines, remarks, polylines = [])
 			}
 
 			if (m.ani.poly) {
-				const parse = profile.parsePolyline(locations)
+				const parse = profile.parsePolyline(data)
 				res.polyline = parse(m.ani.poly)
 			} else if (m.ani.polyG) {
 				let p = m.ani.polyG.polyXL
 				p = Array.isArray(p) && polylines[p[0]]
 				// todo: there can be >1 polyline
-				const parse = profile.parsePolyline(locations)
+				const parse = profile.parsePolyline(data)
 				res.polyline = p && parse(p) || null
 			}
 		}

--- a/parse/movement.js
+++ b/parse/movement.js
@@ -38,13 +38,13 @@ const createParseMovement = (profile, data) => {
 			}
 
 			if (m.ani.poly) {
-				const parse = profile.parsePolyline(data)
+				const parse = profile.parsePolyline(profile, data)
 				res.polyline = parse(m.ani.poly)
 			} else if (m.ani.polyG) {
 				let p = m.ani.polyG.polyXL
 				p = Array.isArray(p) && polylines[p[0]]
 				// todo: there can be >1 polyline
-				const parse = profile.parsePolyline(data)
+				const parse = profile.parsePolyline(profile, data)
 				res.polyline = p && parse(p) || null
 			}
 		}

--- a/parse/movement.js
+++ b/parse/movement.js
@@ -10,7 +10,7 @@ const createParseMovement = (profile, data) => {
 	// todo: what is m.ani.dirGeo[n]? maybe the speed?
 	// todo: what is m.ani.proc[n]? wut?
 	const parseMovement = (m) => {
-		const pStopover = profile.parseStopover(profile, data, m.date)
+		const pStopover = profile.parseStopover(profile, opt, data, m.date)
 
 		const res = {
 			direction: profile.parseStationName(m.dirTxt),
@@ -38,13 +38,13 @@ const createParseMovement = (profile, data) => {
 			}
 
 			if (m.ani.poly) {
-				const parse = profile.parsePolyline(profile, data)
+				const parse = profile.parsePolyline(profile, opt, data)
 				res.polyline = parse(m.ani.poly)
 			} else if (m.ani.polyG) {
 				let p = m.ani.polyG.polyXL
 				p = Array.isArray(p) && polylines[p[0]]
 				// todo: there can be >1 polyline
-				const parse = profile.parsePolyline(profile, data)
+				const parse = profile.parsePolyline(profile, opt, data)
 				res.polyline = p && parse(p) || null
 			}
 		}

--- a/parse/movement.js
+++ b/parse/movement.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const createParseMovement = (profile, data) => {
+const createParseMovement = (profile, opt, data) => {
 	const {locations, lines, remarks, polylines} = data
 
 	// todo: what is m.dirGeo? maybe the speed?

--- a/parse/nearby.js
+++ b/parse/nearby.js
@@ -6,9 +6,9 @@
 // todo: what is s.wt?
 // todo: what is s.dur?
 
-// todo: [breaking] change to createParseNearby(profile, lines) => (n) => nearby
-const parseNearby = (profile, n, lines) => {
-	const res = profile.parseLocation(profile, n, lines)
+// todo: [breaking] change to createParseNearby(profile, data) => (n) => nearby
+const parseNearby = (profile, data, n) => {
+	const res = profile.parseLocation(profile, data, n)
 	res.distance = n.dist
 	return res
 }

--- a/parse/nearby.js
+++ b/parse/nearby.js
@@ -7,8 +7,8 @@
 // todo: what is s.dur?
 
 // todo: [breaking] change to createParseNearby(profile, data) => (n) => nearby
-const parseNearby = (profile, data, n) => {
-	const res = profile.parseLocation(profile, data, n)
+const parseNearby = (profile, opt, data, n) => {
+	const res = profile.parseLocation(profile, opt, data, n)
 	res.distance = n.dist
 	return res
 }

--- a/parse/polyline.js
+++ b/parse/polyline.js
@@ -3,7 +3,7 @@
 const {toGeoJSON} = require('@mapbox/polyline')
 const distance = require('gps-distance')
 
-const createParsePolyline = ({locations}) => {
+const createParsePolyline = (profile, {locations}) => {
 	// todo: what is p.delta?
 	// todo: what is p.type?
 	// todo: what is p.crdEncS?

--- a/parse/polyline.js
+++ b/parse/polyline.js
@@ -3,7 +3,7 @@
 const {toGeoJSON} = require('@mapbox/polyline')
 const distance = require('gps-distance')
 
-const createParsePolyline = (profile, {locations}) => {
+const createParsePolyline = (profile, opt, {locations}) => {
 	// todo: what is p.delta?
 	// todo: what is p.type?
 	// todo: what is p.crdEncS?

--- a/parse/polyline.js
+++ b/parse/polyline.js
@@ -3,7 +3,7 @@
 const {toGeoJSON} = require('@mapbox/polyline')
 const distance = require('gps-distance')
 
-const createParsePolyline = (locations) => {
+const createParsePolyline = ({locations}) => {
 	// todo: what is p.delta?
 	// todo: what is p.type?
 	// todo: what is p.crdEncS?

--- a/parse/stopover.js
+++ b/parse/stopover.js
@@ -2,10 +2,10 @@
 
 // todo: arrivalDelay, departureDelay or only delay ?
 // todo: arrivalPlatform, departurePlatform
-const createParseStopover = (profile, stations, lines, remarks, date) => {
+const createParseStopover = (profile, {locations, lines, remarks}, date) => {
 	const parseStopover = (st) => {
 		const res = {
-			station: stations[parseInt(st.locX)] || null,
+			station: locations[parseInt(st.locX)] || null,
 			arrival: null,
 			arrivalDelay: null,
 			departure: null,

--- a/parse/stopover.js
+++ b/parse/stopover.js
@@ -2,7 +2,7 @@
 
 // todo: arrivalDelay, departureDelay or only delay ?
 // todo: arrivalPlatform, departurePlatform
-const createParseStopover = (profile, {locations, lines, remarks}, date) => {
+const createParseStopover = (profile, opt, {locations, lines, remarks}, date) => {
 	const parseStopover = (st) => {
 		const res = {
 			station: locations[parseInt(st.locX)] || null,


### PR DESCRIPTION
This PR aligns the signatures of all higher-level parsers.

- Passing in `profile` and always calling `profile.parse…()` allows people to override single parsers (e.g. `parseLocation`) so that even deeply nested locations will be parsed with the custom logic.
- Adding `opt` allows us to add options like `parsePolyline` or `parseStationLines` to `hafas-client` in the future without changing the signature again.