### PR TITLE
add reachableFrom method

### DIFF
--- a/docs/reachable-from.md
+++ b/docs/reachable-from.md
@@ -1,10 +1,10 @@
-# `reachableFrom(location, [opt])`
+# `reachableFrom(address, [opt])`
 
-This method can be used to compute the area around a location that is reachable within a certain time. This concept is called [isochrone diagram](https://en.wikipedia.org/wiki/Isochrone_map#Transportation_planning).
+This method can be used to get stations reachable within a certain time from an address. This concept is called [isochrone diagram](https://en.wikipedia.org/wiki/Isochrone_map#Transportation_planning).
 
-*Note*: It appears that HAFAS cannot generate actual isochrones, but a list of reachable stations, which you can estimate the isochrone(s) from.
+*Note*: It appears that HAFAS cannot generate actual isochrones, but only the list of reachable stations, which you can estimate the isochrone(s) from.
 
-`location` must be an [*FPTF* `location` object](https://github.com/public-transport/friendly-public-transport-format/blob/1.1.1/spec/readme.md#location-objects).
+`address` must be an [*FPTF* `location` object](https://github.com/public-transport/friendly-public-transport-format/blob/1.1.1/spec/readme.md#location-objects).
 
 With `opt`, you can override the default options, which look like this:
 
@@ -24,7 +24,7 @@ With `opt`, you can override the default options, which look like this:
 
 ## Response
 
-`reachableFrom(loc, [opt])` returns an array, in which each item has a `duration` and an array of [*Friendly Public Transport Format* `1.1.1`](https://github.com/public-transport/friendly-public-transport-format/tree/1.1.1) stations.
+`reachableFrom(address, [opt])` returns an array, in which each item has a `duration` and an array of [*Friendly Public Transport Format* `1.1.1`](https://github.com/public-transport/friendly-public-transport-format/tree/1.1.1) stations.
 
 As an example, we're going to use the [VBB profile](../p/vbb):
 

--- a/docs/reachable-from.md
+++ b/docs/reachable-from.md
@@ -1,0 +1,92 @@
+# `reachableFrom(location, [opt])`
+
+This method can be used to compute the area around a location that is reachable within a certain time. This concept is called [isochrone diagram](https://en.wikipedia.org/wiki/Isochrone_map#Transportation_planning).
+
+*Note*: It appears that HAFAS cannot generate actual isochrones, but a list of reachable stations, which you can estimate the isochrone(s) from.
+
+`location` must be an [*FPTF* `location` object](https://github.com/public-transport/friendly-public-transport-format/blob/1.1.1/spec/readme.md#location-objects).
+
+With `opt`, you can override the default options, which look like this:
+
+```js
+{
+	when: new Date(),
+	maxTransfers: 5, // maximum of 5 transfers
+	maxDuration: 20, // maximum travel duration in minutes
+	products: {
+		// These entries may vary from profile to profile!
+		suburban: true,
+		subway: true
+		// …
+	}
+}
+```
+
+## Response
+
+`reachableFrom(loc, [opt])` returns an array, in which each item has a `duration` and an array of [*Friendly Public Transport Format* `1.1.1`](https://github.com/public-transport/friendly-public-transport-format/tree/1.1.1) stations.
+
+As an example, we're going to use the [VBB profile](../p/vbb):
+
+```js
+const createClient = require('hafas-client')
+const vbbProfile = require('hafas-client/p/vbb')
+
+const client = createClient(vbbProfile, 'my-awesome-program')
+
+client.reachableFrom({
+	type: 'location',
+	address: '13353 Berlin-Wedding, Torfstr. 17',
+	latitude: 52.541797,
+	longitude: 13.350042
+}, {
+	maxDuration: 10 // minutes
+})
+.then(console.log)
+.catch(console.error)
+```
+
+The response may look like this:
+
+```js
+[
+	{
+		duration: 2,
+		stations: [
+			{
+				type: 'stop',
+				id: '900000009101',
+				name: 'U Amrumer Str.',
+				location: {type: 'location', latitude: 52.542201, longitude: 13.34953},
+				products: { /* … */ }
+			}
+		]
+	}, {
+		duration: 3,
+		stations: [
+			{
+				type: 'stop',
+				id: '900000001201',
+				name: 'S+U Westhafen',
+				location: {type: 'location', latitude: 52.536179, longitude: 13.343839},
+				products: { /* … */ }
+			}
+			// …
+		]
+	},
+	// …
+	{
+		duration: 10,
+		stations: [
+			{
+				type: 'stop',
+				id: '900000001203',
+				name: 'Döberitzer Str.',
+				location: {type: 'location', latitude: 52.530668, longitude: 13.36811},
+				products: { /* … */ }
+			}
+			// …
+		]
+	}
+]
+```

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -9,7 +9,7 @@
 - [`station(id, [opt])`](station.md) – get details about a station
 - [`nearby(location, [opt])`](nearby.md) – show stations & POIs around
 - [`radar(north, west, south, east, [opt])`](radar.md) – find all vehicles currently in a certain area
-- [`reachableFrom(location, [opt])`](reachable-from.md) – get all stations reachable from a location within `n` minutes
+- [`reachableFrom(address, [opt])`](reachable-from.md) – get all stations reachable from an address within `n` minutes
 
 ## Writing a profile
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -9,6 +9,7 @@
 - [`station(id, [opt])`](station.md) – get details about a station
 - [`nearby(location, [opt])`](nearby.md) – show stations & POIs around
 - [`radar(north, west, south, east, [opt])`](radar.md) – find all vehicles currently in a certain area
+- [`reachableFrom(location, [opt])`](reachable-from.md) – get all stations reachable from a location within `n` minutes
 
 ## Writing a profile
 

--- a/index.js
+++ b/index.js
@@ -463,8 +463,8 @@ const createClient = (profile, userAgent, request = _request) => {
 		})
 	}
 
-	const reachableFrom = (location, opt = {}) => {
-		validateLocation(location, 'location')
+	const reachableFrom = (address, opt = {}) => {
+		validateLocation(address, 'address')
 
 		opt = Object.assign({
 			when: Date.now(),
@@ -477,7 +477,7 @@ const createClient = (profile, userAgent, request = _request) => {
 		return request(profile, userAgent, opt, {
 			meth: 'LocGeoReach',
 			req: {
-				loc: profile.formatLocation(profile, location, 'location'),
+				loc: profile.formatLocation(profile, address, 'address'),
 				maxDur: opt.maxDuration,
 				maxChg: opt.maxTransfers,
 				date: profile.formatDate(profile, opt.when),

--- a/p/bvg/example.js
+++ b/p/bvg/example.js
@@ -22,6 +22,15 @@ client.journeys('900000003201', '900000024101', {results: 1, polylines: true})
 // 	south: 52.51942,
 // 	east: 13.41709
 // }, {results: 10})
+// client.reachableFrom({
+// 	type: 'location',
+// 	address: '13353 Berlin-Wedding, Torfstr. 17',
+// 	latitude: 52.541797,
+// 	longitude: 13.350042
+// }, {
+// 	when: new Date('2018-08-27T10:00:00+0200'),
+// 	maxDuration: 10
+// })
 
 // .then(([journey]) => {
 // 	const leg = journey.legs[0]

--- a/p/bvg/index.js
+++ b/p/bvg/index.js
@@ -106,7 +106,9 @@ const bvgProfile = {
 	formatStation,
 
 	trip: true,
-	radar: true
+	radar: true,
+	refreshJourney: true,
+	reachableFrom: true
 }
 
 module.exports = bvgProfile

--- a/p/cmta/example.js
+++ b/p/cmta/example.js
@@ -22,6 +22,15 @@ client.journeys('000002370', '000005919', {results: 1, polylines: true})
 // 	south: 30.225378,
 // 	east: -97.786692
 // }, {results: 10})
+// client.reachableFrom({
+// 	type: 'location',
+// 	address: '604 W 9TH ST, Austin, TX 78701',
+// 	latitude: 30.272910,
+// 	longitude: -97.747883
+// }, {
+// 	when: new Date('2018-08-27T10:00:00+0200'),
+// 	maxDuration: 15
+// })
 
 // .then(([journey]) => {
 // 	const leg = journey.legs[0]

--- a/p/cmta/index.js
+++ b/p/cmta/index.js
@@ -27,7 +27,8 @@ const cmtaProfile = {
 
 	trip: true,
 	radar: true,
-	refreshJourney: true
+	refreshJourney: true,
+	reachableFrom: true
 }
 
 module.exports = cmtaProfile

--- a/p/db/example.js
+++ b/p/db/example.js
@@ -17,6 +17,15 @@ client.journeys('8011167', '8000261', {results: 1, tickets: true})
 // 	latitude: 52.4751309,
 // 	longitude: 13.3656537
 // }, {results: 1})
+// client.reachableFrom({
+// 	type: 'location',
+// 	address: '13353 Berlin-Wedding, Torfstr. 17',
+// 	latitude: 52.541797,
+// 	longitude: 13.350042
+// }, {
+// 	when: new Date('2018-08-27T10:00:00+0200'),
+// 	maxDuration: 50
+// })
 
 .then((data) => {
 	console.log(require('util').inspect(data, {depth: null}))

--- a/p/db/index.js
+++ b/p/db/index.js
@@ -319,7 +319,8 @@ const dbProfile = {
 
 	formatStation,
 
-	trip: true // todo: #49
+	trip: true, // todo: #49
+	reachableFrom: true
 }
 
 module.exports = dbProfile

--- a/p/insa/index.js
+++ b/p/insa/index.js
@@ -28,6 +28,7 @@ const insaProfile = {
 	trip: true,
 	radar: true,
 	refreshJourney: false
+	// todo: upgrade to version `1.13` in order to enable `reachableFrom: true`
 }
 
 module.exports = insaProfile;

--- a/p/nahsh/example.js
+++ b/p/nahsh/example.js
@@ -18,6 +18,15 @@ client.journeys('8000103', '8000199', {results: 10, tickets: true})
 // 	longitude: 10.116424
 // }, {distance: 60})
 // client.radar(54.4, 10.0, 54.2, 10.2, {results: 10})
+// client.reachableFrom({
+// 	type: 'location',
+// 	address: 'Husum, Berliner Straße 80',
+// 	latitude: 54.488995,
+// 	longitude: 9.056263
+// }, {
+// 	when: new Date('2018-08-27T10:00:00+0200'),
+// 	maxDuration: 20
+// })
 
 .then((data) => {
 	console.log(require('util').inspect(data, {depth: null}))

--- a/p/nahsh/index.js
+++ b/p/nahsh/index.js
@@ -104,7 +104,8 @@ const nahshProfile = {
 	parseMovement: createParseMovement,
 
 	trip: true,
-	radar: true // todo: see #34
+	radar: true, // todo: see #34
+	reachableFrom: true
 }
 
 module.exports = nahshProfile

--- a/p/oebb/example.js
+++ b/p/oebb/example.js
@@ -22,6 +22,16 @@ client.journeys('1291501', '8100002', {results: 1})
 // 	south: 47.773278,
 // 	east: 13.07562
 // }, {results: 10})
+// client.reachableFrom({
+// 	type: 'location',
+// 	id: '970053039',
+// 	name: 'Graz, BILLA, Hauptplatz',
+// 	latitude: 47.070656,
+// 	longitude: 15.438002
+// }, {
+// 	when: new Date('2018-08-27T10:00:00+0200'),
+// 	maxDuration: 20
+// })
 
 .then((data) => {
 	console.log(require('util').inspect(data, {depth: null}))

--- a/p/oebb/index.js
+++ b/p/oebb/index.js
@@ -72,7 +72,8 @@ const oebbProfile = {
 	parseMovement: createParseMovement,
 
 	trip: true,
-	radar: true
+	radar: true,
+	reachableFrom: true
 }
 
 module.exports = oebbProfile

--- a/p/vbb/example.js
+++ b/p/vbb/example.js
@@ -22,6 +22,15 @@ client.journeys('900000003201', '900000024101', {results: 1, polylines: true})
 // 	south: 52.51942,
 // 	east: 13.41709
 // }, {results: 10})
+// client.reachableFrom({
+// 	type: 'location',
+// 	address: '13353 Berlin-Wedding, Torfstr. 17',
+// 	latitude: 52.541797,
+// 	longitude: 13.350042
+// }, {
+// 	when: new Date('2018-08-27T10:00:00+0200'),
+// 	maxDuration: 10
+// })
 
 // .then(([journey]) => {
 // 	const leg = journey.legs[0]

--- a/p/vbb/index.js
+++ b/p/vbb/index.js
@@ -143,7 +143,8 @@ const vbbProfile = {
 
 	journeysNumF: false,
 	trip: true,
-	radar: true
+	radar: true,
+	reachableFrom: true
 }
 
 module.exports = vbbProfile

--- a/test/bvg.js
+++ b/test/bvg.js
@@ -380,7 +380,7 @@ test('reachableFrom', co(function* (t) {
 	yield testReachableFrom({
 		test: t,
 		reachableFrom: client.reachableFrom,
-		loc: torfstr17,
+		address: torfstr17,
 		when,
 		maxDuration: 15,
 		validate

--- a/test/bvg.js
+++ b/test/bvg.js
@@ -33,6 +33,7 @@ const testDeparturesInDirection = require('./lib/departures-in-direction')
 const testDeparturesWithoutRelatedStations = require('./lib/departures-without-related-stations')
 const testArrivals = require('./lib/arrivals')
 const testJourneysWithDetour = require('./lib/journeys-with-detour')
+const testReachableFrom = require('./lib/reachable-from')
 
 const when = cfg.when
 
@@ -365,5 +366,24 @@ test('radar', co(function* (t) {
 	})
 
 	validate(t, vehicles, 'movements', 'vehicles')
+	t.end()
+}))
+
+test('reachableFrom', co(function* (t) {
+	const torfstr17 = {
+		type: 'location',
+		address: '13353 Berlin-Wedding, Torfstr. 17',
+		latitude: 52.541797,
+		longitude: 13.350042
+	}
+
+	yield testReachableFrom({
+		test: t,
+		reachableFrom: client.reachableFrom,
+		loc: torfstr17,
+		when,
+		maxDuration: 15,
+		validate
+	})
 	t.end()
 }))

--- a/test/cmta.js
+++ b/test/cmta.js
@@ -20,6 +20,7 @@ const journeysFailsWithNoProduct = require('./lib/journeys-fails-with-no-product
 const testDepartures = require('./lib/departures')
 const testArrivals = require('./lib/arrivals')
 const testJourneysWithDetour = require('./lib/journeys-with-detour')
+const testReachableFrom = require('./lib/reachable-from')
 
 const when = createWhen(cmtaProfile.timezone, cmtaProfile.locale)
 
@@ -258,5 +259,22 @@ test('radar', co(function* (t) {
 	})
 
 	validate(t, vehicles, 'movements', 'vehicles')
+	t.end()
+}))
+
+test('reachableFrom', co(function* (t) {
+	yield testReachableFrom({
+		test: t,
+		reachableFrom: client.reachableFrom,
+		loc: {
+			type: 'location',
+			address: '604 W 9TH ST, Austin, TX 78701',
+			latitude: 30.272910,
+			longitude: -97.747883
+		},
+		when,
+		maxDuration: 15,
+		validate
+	})
 	t.end()
 }))

--- a/test/cmta.js
+++ b/test/cmta.js
@@ -266,7 +266,7 @@ test('reachableFrom', co(function* (t) {
 	yield testReachableFrom({
 		test: t,
 		reachableFrom: client.reachableFrom,
-		loc: {
+		address: {
 			type: 'location',
 			address: '604 W 9TH ST, Austin, TX 78701',
 			latitude: 30.272910,

--- a/test/db.js
+++ b/test/db.js
@@ -27,6 +27,7 @@ const testDeparturesInDirection = require('./lib/departures-in-direction')
 const testDeparturesWithoutRelatedStations = require('./lib/departures-without-related-stations')
 const testArrivals = require('./lib/arrivals')
 const testJourneysWithDetour = require('./lib/journeys-with-detour')
+const testReachableFrom = require('./lib/reachable-from')
 
 const isObj = o => o !== null && 'object' === typeof o && !Array.isArray(o)
 
@@ -346,5 +347,24 @@ test('station', co(function* (t) {
 	validate(t, s, ['stop', 'station'], 'station')
 	t.equal(s.id, regensburgHbf)
 
+	t.end()
+}))
+
+test('reachableFrom', co(function* (t) {
+	const torfstr17 = {
+		type: 'location',
+		address: 'Torfstraße 17',
+		latitude: 52.5416823,
+		longitude: 13.3491223
+	}
+
+	yield testReachableFrom({
+		test: t,
+		reachableFrom: client.reachableFrom,
+		loc: torfstr17,
+		when,
+		maxDuration: 15,
+		validate
+	})
 	t.end()
 }))

--- a/test/db.js
+++ b/test/db.js
@@ -361,7 +361,7 @@ test('reachableFrom', co(function* (t) {
 	yield testReachableFrom({
 		test: t,
 		reachableFrom: client.reachableFrom,
-		loc: torfstr17,
+		address: torfstr17,
 		when,
 		maxDuration: 15,
 		validate

--- a/test/lib/reachable-from.js
+++ b/test/lib/reachable-from.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const isPlainObject = require('lodash/isPlainObject')
+
+const co = require('./co')
+
+const testReachableFrom = co(function* (cfg) {
+	const {
+		test: t,
+		reachableFrom,
+		loc,
+		when,
+		maxDuration,
+		validate
+	} = cfg
+
+	const results = yield reachableFrom(loc, {
+		when, maxDuration
+	})
+
+	t.ok(Array.isArray(results), 'results must an array')
+	t.ok(results.length > 0, 'results must have >0 items')
+
+	for (let i = 0; i < results.length; i++) {
+		const res = results[i]
+		const name = `results[${i}]`
+
+		t.ok(isPlainObject(res), name + ' must be an object')
+		t.equal(typeof res.duration, 'number', name + '.duration must be a number')
+		t.ok(res.duration > 0, name + '.duration must be >0')
+
+		t.ok(Array.isArray(res.stations), name + '.stations must be an array')
+		t.ok(res.stations.length > 0, name + '.stations must have >0 items')
+
+		for (let j = 0; j < res.stations.length; j++) {
+			validate(t, res.stations[j], ['stop', 'station'], `${name}.stations[${j}]`)
+		}
+	}
+
+	const sorted = results.sort((a, b) => a.duration - b.duration)
+	t.deepEqual(results, sorted, 'results must be sorted by res.duration')
+})
+
+module.exports = testReachableFrom

--- a/test/lib/reachable-from.js
+++ b/test/lib/reachable-from.js
@@ -8,13 +8,13 @@ const testReachableFrom = co(function* (cfg) {
 	const {
 		test: t,
 		reachableFrom,
-		loc,
+		address,
 		when,
 		maxDuration,
 		validate
 	} = cfg
 
-	const results = yield reachableFrom(loc, {
+	const results = yield reachableFrom(address, {
 		when, maxDuration
 	})
 

--- a/test/nahsh.js
+++ b/test/nahsh.js
@@ -23,6 +23,7 @@ const journeysFailsWithNoProduct = require('./lib/journeys-fails-with-no-product
 const testDepartures = require('./lib/departures')
 const testDeparturesInDirection = require('./lib/departures-in-direction')
 const testArrivals = require('./lib/arrivals')
+const testReachableFrom = require('./lib/reachable-from')
 
 const when = createWhen('Europe/Berlin', 'de-DE')
 
@@ -345,5 +346,24 @@ test('radar', co(function* (t) {
 	})
 	validate(t, vehicles, 'movements', 'vehicles')
 
+	t.end()
+}))
+
+test('reachableFrom', co(function* (t) {
+	const berlinerStr = {
+		type: 'location',
+		address: 'Husum, Berliner Straße 80',
+		latitude: 54.488995,
+		longitude: 9.056263
+	}
+
+	yield testReachableFrom({
+		test: t,
+		reachableFrom: client.reachableFrom,
+		loc: berlinerStr,
+		when,
+		maxDuration: 60,
+		validate
+	})
 	t.end()
 }))

--- a/test/nahsh.js
+++ b/test/nahsh.js
@@ -360,7 +360,7 @@ test('reachableFrom', co(function* (t) {
 	yield testReachableFrom({
 		test: t,
 		reachableFrom: client.reachableFrom,
-		loc: berlinerStr,
+		address: berlinerStr,
 		when,
 		maxDuration: 60,
 		validate

--- a/test/vbb.js
+++ b/test/vbb.js
@@ -27,6 +27,7 @@ const testDeparturesInDirection = require('./lib/departures-in-direction')
 const testDeparturesWithoutRelatedStations = require('./lib/departures-without-related-stations')
 const testArrivals = require('./lib/arrivals')
 const testJourneysWithDetour = require('./lib/journeys-with-detour')
+const testReachableFrom = require('./lib/reachable-from')
 
 const when = cfg.when
 
@@ -355,5 +356,24 @@ test('radar', co(function* (t) {
 	})
 
 	validate(t, vehicles, 'movements', 'vehicles')
+	t.end()
+}))
+
+test('reachableFrom', co(function* (t) {
+	const torfstr17 = {
+		type: 'location',
+		address: '13353 Berlin-Wedding, Torfstr. 17',
+		latitude: 52.541797,
+		longitude: 13.350042
+	}
+
+	yield testReachableFrom({
+		test: t,
+		reachableFrom: client.reachableFrom,
+		loc: torfstr17,
+		when,
+		maxDuration: 15,
+		validate
+	})
 	t.end()
 }))

--- a/test/vbb.js
+++ b/test/vbb.js
@@ -370,7 +370,7 @@ test('reachableFrom', co(function* (t) {
 	yield testReachableFrom({
 		test: t,
 		reachableFrom: client.reachableFrom,
-		loc: torfstr17,
+		address: torfstr17,
 		when,
 		maxDuration: 15,
 		validate


### PR DESCRIPTION
The `reachableFrom(address, [opt])` method returns stations reachable from ~~any station, POI or address~~ an address.

Because the isochrones generated by [the HAFAS web app from CMTA](https://capmetro.hafas.cloud/old/index.html) don't seem to be *real* isochrones, but just circle from reachable stations, with radiuses based on the remaining walking time, this method does not return isochrones.