### PR TITLE
Parse additional line names

### DIFF
--- a/p/db/index.js
+++ b/p/db/index.js
@@ -42,7 +42,13 @@ const createParseLine = (profile, opt, data) => {
 	const parseLine = _createParseLine(profile, opt, data)
 	const parseLineWithAdditionalName = (l) => {
 		const res = parseLine(l)
-		if (l.addName) res.additionalName = l.addName
+		if (l.nameS && ['bus', 'tram', 'ferry'].includes(res.product)) {
+			res.name = l.nameS
+		}
+		if (l.addName) {
+			res.additionalName = res.name
+			res.name = l.addName
+		}
 		return res
 	}
 	return parseLineWithAdditionalName

--- a/p/db/index.js
+++ b/p/db/index.js
@@ -3,6 +3,7 @@
 const trim = require('lodash/trim')
 
 const _createParseJourney = require('../../parse/journey')
+const _createParseLine = require('../../parse/line')
 const _parseHint = require('../../parse/hint')
 const _formatStation = require('../../format/station')
 const {bike} = require('../../format/filters')
@@ -12,7 +13,7 @@ const formatLoyaltyCard = require('./loyalty-cards').format
 
 const transformReqBody = (body) => {
 	body.client = {id: 'DB', v: '16040000', type: 'IPH', name: 'DB Navigator'}
-	body.ext = 'DB.R15.12.a'
+	body.ext = 'DB.R18.06.a'
 	body.ver = '1.16'
 	body.auth = {type: 'AID', aid: 'n91dB8Z77MLdoR0K'}
 
@@ -35,6 +36,16 @@ const transformJourneysQuery = (query, opt) => {
 	}
 
 	return query
+}
+
+const createParseLine = (profile, opt, data) => {
+	const parseLine = _createParseLine(profile, opt, data)
+	const parseLineWithAdditionalName = (l) => {
+		const res = parseLine(l)
+		if (l.addName) res.additionalName = l.addName
+		return res
+	}
+	return parseLineWithAdditionalName
 }
 
 const createParseJourney = (profile, opt, data) => {
@@ -315,6 +326,7 @@ const dbProfile = {
 
 	// todo: parseLocation
 	parseJourney: createParseJourney,
+	parseLine: createParseLine,
 	parseHint,
 
 	formatStation,

--- a/test/db.js
+++ b/test/db.js
@@ -82,6 +82,7 @@ const regensburgHbf = '8000309'
 const blnOstbahnhof = '8010255'
 const blnTiergarten = '8089091'
 const blnJannowitzbrücke = '8089019'
+const potsdamHbf = '8012666'
 
 test('journeys – Berlin Schwedter Str. to München Hbf', co(function* (t) {
 	const journeys = yield client.journeys(blnSchwedterStr, münchenHbf, {
@@ -363,6 +364,15 @@ test('station', co(function* (t) {
 	validate(t, s, ['stop', 'station'], 'station')
 	t.equal(s.id, regensburgHbf)
 
+	t.end()
+}))
+
+test('line with additionalName', co(function* (t) {
+	const departures = yield client.departures(potsdamHbf, {
+		duration: 12 * 60, // 12 minutes
+		products: {bus: false, suburban: false, tram: false}
+	})
+	t.ok(departures.some(d => d.line && d.line.additionalName))
 	t.end()
 }))
 


### PR DESCRIPTION
Some DB lines contain an additional attribute called `addName` (only with the updated `body.ext`, for some reason), e.g.

```js
{
	name: 'RE 3177',
	number: '3177',
	icoX: 1,
	cls: 8,
	oprX: 0,
	prodCtx:
	{
		name: 'RE  3177',
		num: '3177',
		matchId: '1',
		catOut: 'RE',
		catOutS: 'RE',
		catOutL: 'Regional-Express',
		catIn: 'RE',
		catCode: '3',
		admin: '800154',
		addName: 'RE     1'
	},
	addName: 'RE 1'
}
```

This PR adds support for this (renamed to `line.additionalName`) in the DB profile.