### PR TITLE
prepare code for remarks(bbox) & remark(id)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -103,16 +103,6 @@ const request = (profile, userAgent, opt, data) => {
 		const d = b.svcResL[0].res
 		const c = d.common || {}
 
-		d.hints = []
-		if (opt.remarks && Array.isArray(c.remL)) {
-			const icons = opt.remarks && c.icoL || []
-			d.hints = c.remL.map(hint => profile.parseHint(profile, hint, icons))
-		}
-		d.warnings = []
-		if (opt.remarks && Array.isArray(c.himL)) {
-			const icons = opt.remarks && c.icoL || []
-			d.warnings = c.himL.map(w => profile.parseWarning(profile, w, icons))
-		}
 		if (Array.isArray(c.opL)) {
 			d.operators = c.opL.map(op => profile.parseOperator(profile, op))
 		}
@@ -136,6 +126,16 @@ const request = (profile, userAgent, opt, data) => {
 				} else if (raw.isMainMast) loc.type = 'station'
 			}
 		}
+
+		d.hints = []
+		if (opt.remarks && Array.isArray(c.remL)) {
+			d.hints = c.remL.map(hint => profile.parseHint(profile, hint, {...c, ...d}))
+		}
+		d.warnings = []
+		if (opt.remarks && Array.isArray(c.himL)) {
+			d.warnings = c.himL.map(w => profile.parseWarning(profile, w, {...c, ...d}))
+		}
+
 		return d
 	})
 }

--- a/parse/hint.js
+++ b/parse/hint.js
@@ -5,7 +5,8 @@ const codesByIcon = Object.assign(Object.create(null), {
 })
 
 // todo: is passing in profile necessary?
-const parseHint = (profile, h, icons) => {
+const parseHint = (profile, h, data) => {
+	const icons = data.icoL || []
 	// todo: C
 	// todo:
 	// { type: 'Q',

--- a/parse/warning.js
+++ b/parse/warning.js
@@ -9,7 +9,8 @@ const typesByIcon = Object.assign(Object.create(null), {
 })
 
 // todo: is passing in profile necessary?
-const parseWarning = (profile, w, icons) => {
+const parseWarning = (profile, w, data) => {
+	const icons = data.icoL || []
 	// todo: hid, act, pub, lead, tckr, icoX, fLocX, tLocX, prod, comp,
 	// todo: cat (1, 2), pubChL
 	// pubChL:

--- a/parse/warning.js
+++ b/parse/warning.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const brToNewline = require('br2nl')
+const omit = require('lodash/omit')
 
 const parseDateTime = require('./date-time')
 
@@ -8,11 +9,28 @@ const typesByIcon = Object.assign(Object.create(null), {
 	HimWarn: 'status'
 })
 
-// todo: is passing in profile necessary?
+const parseMsgEdge = (profile, data) => (e) => {
+	const res = omit(e, ['icoX', 'fLocX', 'tLocX'])
+	const icons = data.icoL || []
+	res.icon = 'number' === typeof e.icoX && icons[e.icoX] || null
+	res.fromLoc = 'number' === typeof e.fLocX && data.locations[e.fLocX] || null
+	res.toLoc = 'number' === typeof e.tLocX && data.locations[e.tLocX] || null
+	return res
+}
+const parseMsgEvent = (profile, data) => (e) => {
+	return {
+		fromLoc: 'number' === typeof e.fLocX && data.locations[e.fLocX] || null,
+		toLoc: 'number' === typeof e.tLocX && data.locations[e.tLocX] || null,
+		start: parseDateTime(profile, e.fDate, e.fTime, null),
+		end: parseDateTime(profile, e.tDate, e.tTime, null),
+		sections: e.sectionNums || [] // todo: parse
+	}
+}
+
 const parseWarning = (profile, w, data) => {
 	const icons = data.icoL || []
-	// todo: hid, act, pub, lead, tckr, icoX, fLocX, tLocX, prod, comp,
-	// todo: cat (1, 2), pubChL
+	// todo: act, pub, lead, tckr, fLocX, tLocX, prod, comp,
+	// todo: cat (1, 2), pubChL, rRefL, impactL
 	// pubChL:
 	// [ { name: 'timetable',
 	// fDate: '20180606',
@@ -24,16 +42,37 @@ const parseWarning = (profile, w, data) => {
 	// fTime: '073000',
 	// tDate: '20180713',
 	// tTime: '030000' } ]
+	// { name: '1',
+	// fDate: '20190219',
+	// fTime: '000000',
+	// tDate: '20190225',
+	// tTime: '120000' }
 
 	const icon = 'number' === typeof w.icoX && icons[w.icoX] || null
 	const type = icon && icon.res && typesByIcon[icon.res] || 'warning'
 
 	const res = {
 		type,
-		summary: brToNewline(w.head),
-		text: brToNewline(w.text),
+		id: w.hid || null,
+		summary: w.head ? brToNewline(w.head) : null, // todo: decode HTML entities?
+		text: w.text ? brToNewline(w.text) : null, // todo: decode HTML entities?
+		icon,
 		priority: w.prio,
 		category: w.cat || null // todo: parse to sth meaningful
+	}
+	if ('prod' in w) res.products = profile.parseProducts(w.prod)
+
+	if (w.edgeRefL && data.himMsgEdgeL) {
+		res.edges = w.edgeRefL
+		.map(i => data.himMsgEdgeL[i])
+		.filter(e => !!e)
+		.map(parseMsgEdge(profile, data))
+	}
+	if (w.eventRefL && data.himMsgEventL) {
+		res.events = w.eventRefL
+		.map(i => data.himMsgEventL[i])
+		.filter(e => !!e)
+		.map(parseMsgEvent(profile, data))
 	}
 
 	// todo: pass tzOffset to `parseDateTime`


### PR DESCRIPTION
I discovered that the [disturbance & construction map of DB Netz](https://db-livemaps.hafas.de/bin/query.exe/dn?L=vs_baustellen&tpl=fullscreenmap&mapCenterX=13468894.958496094&mapCenterY=52614722.6179558&mapZoom=12&) is powered by HAFAS.

~~This PR adds two new features: `remarks(bbox, opt = {})` (to fetch hints & warnings in an area) and `remark(id, opt = {})` (to re-fetch details of a specific hint/warning).~~

This PR makes all necessary changes to let [`db-netz-hafas`](https://github.com/derhuerst/db-netz-hafas) build `remarks(bbox)` and `remark(id)` on top.

Things still to do:

- How to expose hints? Does it make sense at all – rename to `warnings(bbox)` & `warning(id)`? Are they the same as `leg`/`departure`/`arrival` hints?
- ~~Do all endpoints have this or just the DB netz one? Should the logic be in [`db-netz-hafas`](https://github.com/derhuerst/db-netz-hafas)?~~ Moved the logic to [`db-netz-hafas`](https://github.com/derhuerst/db-netz-hafas).
- basic tests