### PR TITLE
client ID: install-unique -> process-unique

### DIFF
--- a/lib/generate-install-id.js
+++ b/lib/generate-install-id.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-
-const {randomBytes} = require('crypto')
-
-const id = randomBytes(6).toString('hex')
-process.stdout.write(JSON.stringify(id) + '\n')

--- a/lib/request.js
+++ b/lib/request.js
@@ -3,7 +3,7 @@
 const DEV = process.env.NODE_ENV === 'dev'
 const DEBUG = process.env.DEBUG === 'hafas-client'
 
-const {join} = require('path')
+const {randomBytes} = require('crypto')
 const createHash = require('create-hash')
 const captureStackTrace = DEV ? require('capture-stack-trace') : () => {}
 const {stringify} = require('qs')
@@ -11,15 +11,7 @@ const Promise = require('pinkie-promise')
 const {fetch} = require('fetch-ponyfill')({Promise})
 const {byErrorCode} = require('./errors')
 
-let id
-try {
-	id = require('../id.json')
-} catch (err) {
-	const p = join(__dirname, '..', 'id.json')
-	console.error(`Failed to load the install-unique ID from ${p}.`)
-	process.exit(1)
-}
-
+const id = randomBytes(6).toString('hex')
 const randomizeUserAgent = (userAgent) => {
 	const i = Math.round(Math.random() * userAgent.length)
 	return userAgent.slice(0, i) + id + userAgent.slice(i)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
 	},
 	"scripts": {
 		"test": "env NODE_ENV=dev node test/index.js",
-		"prepublishOnly": "npm test | tap-spec",
-		"install": "node lib/generate-install-id.js >id.json"
+		"prepublishOnly": "npm test | tap-spec"
 	}
 }


### PR DESCRIPTION
This solves problems with missing permissions, such as derhuerst/db-cli#1. The disadvantage is that we're not sending info about the nr of installations to HACON anymore.