### PR TITLE
hooks: more flexible profile API

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -21,13 +21,12 @@
 There's opt-in support for throttling requests to the endpoint.
 
 ```js
-const withThrottling = require('hafas-client/throttle')
 const createClient = require('hafas-client')
+const withThrottling = require('hafas-client/throttle')
 const dbProfile = require('hafas-client/p/db')
 
 // create a throttled HAFAS client with Deutsche Bahn profile
-const createThrottledClient = withThrottling(createClient)
-const client = createThrottledClient(dbProfile, 'my-awesome-program')
+const client = createClient(withThrottling(dbProfile), 'my-awesome-program')
 
 // Berlin Jungfernheide to München Hbf
 client.journeys('8011167', '8000261', {results: 1})
@@ -39,8 +38,8 @@ You can pass custom values for the nr of requests (`limit`) per interval into `w
 
 ```js
 // 2 requests per second
-const createThrottledClient = withThrottling(createClient, 2, 1000)
-const client = createThrottledClient(dbProfile, 'my-awesome-program')
+const throttledDbProfile = withThrottling(dbProfile, 2, 1000)
+const client = createClient(throttledDbProfile, 'my-awesome-program')
 ```
 
 ## Retrying failed requests
@@ -48,13 +47,12 @@ const client = createThrottledClient(dbProfile, 'my-awesome-program')
 There's opt-in support for retrying failed requests to the endpoint.
 
 ```js
-const withRetrying = require('hafas-client/retry')
 const createClient = require('hafas-client')
+const withRetrying = require('hafas-client/retry')
 const dbProfile = require('hafas-client/p/db')
 
 // create a client with Deutsche Bahn profile that will retry on HAFAS errors
-const createRetryingClient = withRetrying(createClient)
-const client = createRetryingClient(dbProfile, 'my-awesome-program')
+const client = createClient(withRetrying(dbProfile), 'my-awesome-program')
 
 // Berlin Jungfernheide to München Hbf
 client.journeys('8011167', '8000261', {results: 1})
@@ -66,12 +64,12 @@ You can pass custom options into `withRetrying`. They will be passed into [`retr
 
 ```js
 // retry 2 times, after 10 seconds & 30 seconds
-const createRetryingClient = withRetrying(createClient, {
+const retryingDbProfile = withRetrying(dbProfile, {
 	retries: 2,
 	minTimeout: 10 * 1000,
 	factor: 3
 })
-const client = createRetryingClient(dbProfile, 'my-awesome-program')
+const client = createClient(retryingDbProfile, 'my-awesome-program')
 ```
 
 ## Writing a profile

--- a/docs/writing-a-profile.md
+++ b/docs/writing-a-profile.md
@@ -35,24 +35,32 @@ Assuming their HAFAS endpoint returns all line names prefixed with `foo `, we ca
 
 ```js
 // get the default line parser
-const createParseLine = require('hafas-client/parse/line')
+const parseLine = require('hafas-client/parse/line')
 
-const createParseLineWithoutFoo = (profile, opt, data) => {
-	const parseLine = createParseLine(profile, opt, data)
-
-	// wrapper function with additional logic
-	const parseLineWithoutFoo = (l) => {
-		const line = parseLine(l)
-		line.name = line.name.replace(/foo /g, '')
-		return line
-	}
-	return parseLineWithoutFoo
+// wrapper function with additional logic
+const parseLineWithoutFoo = (ctx, rawLine) => {
+	const line = parseLine(ctx, rawLine)
+	line.name = line.name.replace(/foo /g, '')
+	return line
 }
 
-profile.parseLine = createParseLineWithoutFoo
+myProfile.parseLine = parseLineWithoutFoo
 ```
 
 If you pass this profile into `hafas-client`, the `parseLine` method will override [the default one](../parse/line.js).
+
+You can also use the `parseHook` helper to reduce boilerplate:
+
+```js
+const {parseHook} = require('hafas-client/lib/profile-hooks')
+
+const removeFoo = (ctx, rawLine) => ({
+	...ctx.parsed,
+	name: line.name.replace(/foo /g, '')
+})
+
+myProfile.parseLine = parseHook(parseLine, removeFoo)
+```
 
 ## 1. Setup
 

--- a/format/locations-req.js
+++ b/format/locations-req.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const formatLocationsReq = (ctx, query) => {
+	const {profile, opt} = ctx
+
+	return {
+		cfg: {polyEnc: 'GPA'},
+		meth: 'LocMatch',
+		req: {input: {
+			loc: {
+				type: profile.formatLocationFilter(opt.stops, opt.addresses, opt.poi),
+				name: opt.fuzzy ? query + '?' : query
+			},
+			maxLoc: opt.results,
+			field: 'S' // todo: what is this?
+		}}
+	}
+}
+
+module.exports = formatLocationsReq

--- a/format/nearby-req.js
+++ b/format/nearby-req.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const nearbyReq = (ctx, location) => {
+	const {profile, opt} = ctx
+
+	return {
+		cfg: {polyEnc: 'GPA'},
+		meth: 'LocGeoPos',
+		req: {
+			ring: {
+				cCrd: {
+					x: profile.formatCoord(location.longitude),
+					y: profile.formatCoord(location.latitude)
+				},
+				maxDist: opt.distance || -1,
+				minDist: 0
+			},
+			getPOIs: !!opt.poi,
+			getStops: !!opt.stops,
+			maxLoc: opt.results
+		}
+	}
+}
+
+module.exports = nearbyReq

--- a/format/products-filter.js
+++ b/format/products-filter.js
@@ -4,34 +4,32 @@ const isObj = require('lodash/isObject')
 
 const hasProp = (o, k) => Object.prototype.hasOwnProperty.call(o, k)
 
-const createFormatProductsFilter = (profile) => {
+const formatProductsFilter = (ctx, filter) => {
+	if (!isObj(filter)) throw new TypeError('products filter must be an object')
+	const {profile} = ctx
+
 	const byProduct = {}
 	const defaultProducts = {}
 	for (let product of profile.products) {
 		byProduct[product.id] = product
 		defaultProducts[product.id] = product.default
 	}
+	filter = Object.assign({}, defaultProducts, filter)
 
-	const formatProductsFilter = (filter) => {
-		if (!isObj(filter)) throw new TypeError('products filter must be an object')
-		filter = Object.assign({}, defaultProducts, filter)
-
-		let res = 0, products = 0
-		for (let product in filter) {
-			if (!hasProp(filter, product) || filter[product] !== true) continue
-			if (!byProduct[product]) throw new TypeError('unknown product ' + product)
-			products++
-			for (let bitmask of byProduct[product].bitmasks) res = res ^ bitmask
-		}
-		if (products === 0) throw new Error('no products used')
-
-		return {
-			type: 'PROD',
-			mode: 'INC',
-			value: res + ''
-		}
+	let res = 0, products = 0
+	for (let product in filter) {
+		if (!hasProp(filter, product) || filter[product] !== true) continue
+		if (!byProduct[product]) throw new TypeError('unknown product ' + product)
+		products++
+		for (let bitmask of byProduct[product].bitmasks) res = res | bitmask
 	}
-	return formatProductsFilter
+	if (products === 0) throw new Error('no products used')
+
+	return {
+		type: 'PROD',
+		mode: 'INC',
+		value: res + ''
+	}
 }
 
-module.exports = createFormatProductsFilter
+module.exports = formatProductsFilter

--- a/format/radar-req.js
+++ b/format/radar-req.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const formatRadarReq = (ctx, north, west, south, east) => {
+	const {profile, opt} = ctx
+
+	return {
+		meth: 'JourneyGeoPos',
+		req: {
+			maxJny: opt.results,
+			onlyRT: false, // todo: does this mean "only realtime"?
+			date: profile.formatDate(profile, opt.when),
+			time: profile.formatTime(profile, opt.when),
+			// todo: would a ring work here as well?
+			rect: profile.formatRectangle(profile, north, west, south, east),
+			perSize: opt.duration * 1000,
+			perStep: Math.round(opt.duration / Math.max(opt.frames, 1) * 1000),
+			ageOfReport: true, // todo: what is this?
+			jnyFltrL: [
+				profile.formatProductsFilter(ctx, opt.products || {})
+			],
+			trainPosMode: 'CALC' // todo: what is this? what about realtime?
+		}
+	}
+}
+
+module.exports = formatRadarReq

--- a/format/reachable-from-req.js
+++ b/format/reachable-from-req.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const formatReachableFromReq = (ctx, address) => {
+	const {profile, opt} = ctx
+
+	return {
+		meth: 'LocGeoReach',
+		req: {
+			loc: profile.formatLocation(profile, address, 'address'),
+			maxDur: opt.maxDuration === null ? -1 : opt.maxDuration,
+			maxChg: opt.maxTransfers,
+			date: profile.formatDate(profile, opt.when),
+			time: profile.formatTime(profile, opt.when),
+			period: 120, // todo: what is this?
+			jnyFltrL: [
+				profile.formatProductsFilter(ctx, opt.products || {})
+			]
+		}
+	}
+}
+
+module.exports = formatReachableFromReq

--- a/format/station-board-req.js
+++ b/format/station-board-req.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const formatStationBoardReq = (ctx, station, type) => {
+	const {profile, opt} = ctx
+
+	const req = {
+		type,
+		date: profile.formatDate(profile, opt.when),
+		time: profile.formatTime(profile, opt.when),
+		stbLoc: station,
+		dirLoc: opt.direction ? profile.formatStation(opt.direction) : null,
+		jnyFltrL: [
+			profile.formatProductsFilter(ctx, opt.products || {})
+		],
+		dur: opt.duration
+	}
+	if (profile.departuresGetPasslist) req.getPasslist = !!opt.stopovers
+	if (profile.departuresStbFltrEquiv) req.stbFltrEquiv = !opt.includeRelatedStations
+
+	return {
+		meth: 'StationBoard',
+		req
+	}
+}
+
+module.exports = formatStationBoardReq

--- a/format/stop-req.js
+++ b/format/stop-req.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const formatStopReq = (ctx, stopRef) => {
+	return {
+		meth: 'LocDetails',
+		req: {
+			locL: [stopRef]
+		}
+	}
+}
+
+module.exports = formatStopReq

--- a/format/trip-req.js
+++ b/format/trip-req.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const formatTripReq = ({opt}, id, lineName) => {
+	return {
+		cfg: {polyEnc: 'GPA'},
+		meth: 'JourneyDetails',
+		req: {
+			// todo: getTrainComposition
+			jid: id,
+			name: lineName,
+			// HAFAS apparently ignores the date in the trip ID and uses the `date` field.
+			// Thus, it will find a different trip if you pass the wrong date via `opt.when`.
+			// date: profile.formatDate(profile, opt.when),
+			getPolyline: !!opt.polyline
+		}
+	}
+}
+
+module.exports = formatTripReq

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const sortBy = require('lodash/sortBy')
 const pRetry = require('p-retry')
 
 const defaultProfile = require('./lib/default-profile')
-const createParseBitmask = require('./parse/products-bitmask')
 const createFormatProductsFilter = require('./format/products-filter')
 const validateProfile = require('./lib/validate-profile')
 const _request = require('./lib/request')
@@ -32,9 +31,6 @@ const defaults = {
 
 const createClient = (profile, userAgent, opt = {}) => {
 	profile = Object.assign({}, defaultProfile, profile)
-	if (!profile.parseProducts) {
-		profile.parseProducts = createParseBitmask(profile)
-	}
 	if (!profile.formatProductsFilter) {
 		profile.formatProductsFilter = createFormatProductsFilter(profile)
 	}

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const pRetry = require('p-retry')
 const defaultProfile = require('./lib/default-profile')
 const createFormatProductsFilter = require('./format/products-filter')
 const validateProfile = require('./lib/validate-profile')
-const _request = require('./lib/request')
 
 const isNonEmptyString = str => 'string' === typeof str && str.length > 0
 
@@ -25,10 +24,6 @@ const validateLocation = (loc, name = 'location') => {
 	}
 }
 
-const defaults = {
-	request: _request
-}
-
 const createClient = (profile, userAgent, opt = {}) => {
 	profile = Object.assign({}, defaultProfile, profile)
 	if (!profile.formatProductsFilter) {
@@ -39,10 +34,6 @@ const createClient = (profile, userAgent, opt = {}) => {
 	if ('string' !== typeof userAgent) {
 		throw new TypeError('userAgent must be a string');
 	}
-
-	const {
-		request
-	} = Object.assign({}, defaults, opt)
 
 	const _stationBoard = (station, type, parse, opt = {}) => {
 		if (isObj(station)) station = profile.formatStation(station.id)
@@ -88,7 +79,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		if (profile.departuresGetPasslist) req.getPasslist = !!opt.stopovers
 		if (profile.departuresStbFltrEquiv) req.stbFltrEquiv = !opt.includeRelatedStations
 
-		return request({profile, opt}, userAgent, {
+		return profile.request({profile, opt}, userAgent, {
 			meth: 'StationBoard',
 			req
 		})
@@ -227,7 +218,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 			}
 			if (profile.journeysNumF && opt.results !== null) query.numF = opt.results
 
-			return request({profile, opt}, userAgent, {
+			return profile.request({profile, opt}, userAgent, {
 				cfg: {polyEnc: 'GPA'},
 				meth: 'TripSearch',
 				req: profile.transformJourneysQuery({profile, opt}, query)
@@ -274,7 +265,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 			remarks: true // parse & expose hints & warnings?
 		}, opt)
 
-		return request({profile, opt}, userAgent, {
+		return profile.request({profile, opt}, userAgent, {
 			meth: 'Reconstruction',
 			req: {
 				ctxRecon: refreshToken,
@@ -308,7 +299,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		}, opt)
 
 		const f = profile.formatLocationFilter(opt.stops, opt.addresses, opt.poi)
-		return request({profile, opt}, userAgent, {
+		return profile.request({profile, opt}, userAgent, {
 			cfg: {polyEnc: 'GPA'},
 			meth: 'LocMatch',
 			req: {input: {
@@ -336,7 +327,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		opt = Object.assign({
 			linesOfStops: false // parse & expose lines at the stop/station?
 		}, opt)
-		return request({profile, opt}, userAgent, {
+		return profile.request({profile, opt}, userAgent, {
 			meth: 'LocDetails',
 			req: {
 				locL: [stop]
@@ -364,7 +355,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 			linesOfStops: false // parse & expose lines at each stop/station?
 		}, opt)
 
-		return request({profile, opt}, userAgent, {
+		return profile.request({profile, opt}, userAgent, {
 			cfg: {polyEnc: 'GPA'},
 			meth: 'LocGeoPos',
 			req: {
@@ -402,7 +393,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 			remarks: true // parse & expose hints & warnings?
 		}, opt)
 
-		return request({profile, opt}, userAgent, {
+		return profile.request({profile, opt}, userAgent, {
 			cfg: {polyEnc: 'GPA'},
 			meth: 'JourneyDetails',
 			req: {
@@ -451,7 +442,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		if (Number.isNaN(+opt.when)) throw new TypeError('opt.when is invalid')
 
 		const durationPerStep = opt.duration / Math.max(opt.frames, 1) * 1000
-		return request({profile, opt}, userAgent, {
+		return profile.request({profile, opt}, userAgent, {
 			meth: 'JourneyGeoPos',
 			req: {
 				maxJny: opt.results,
@@ -489,7 +480,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		if (Number.isNaN(+opt.when)) throw new TypeError('opt.when is invalid')
 
 		const refetch = () => {
-			return request({profile, opt}, userAgent, {
+			return profile.request({profile, opt}, userAgent, {
 				meth: 'LocGeoReach',
 				req: {
 					loc: profile.formatLocation(profile, address, 'address'),

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const sortBy = require('lodash/sortBy')
 const pRetry = require('p-retry')
 
 const defaultProfile = require('./lib/default-profile')
-const createFormatProductsFilter = require('./format/products-filter')
 const validateProfile = require('./lib/validate-profile')
 
 const isNonEmptyString = str => 'string' === typeof str && str.length > 0
@@ -26,9 +25,6 @@ const validateLocation = (loc, name = 'location') => {
 
 const createClient = (profile, userAgent, opt = {}) => {
 	profile = Object.assign({}, defaultProfile, profile)
-	if (!profile.formatProductsFilter) {
-		profile.formatProductsFilter = createFormatProductsFilter(profile)
-	}
 	validateProfile(profile)
 
 	if ('string' !== typeof userAgent) {
@@ -64,7 +60,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		}, opt)
 		opt.when = new Date(opt.when || Date.now())
 		if (Number.isNaN(+opt.when)) throw new Error('opt.when is invalid')
-		const products = profile.formatProductsFilter(opt.products || {})
+		const products = profile.formatProductsFilter({profile}, opt.products || {})
 
 		const dir = opt.direction ? profile.formatStation(opt.direction) : null
 		const req = {
@@ -162,7 +158,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		}
 
 		const filters = [
-			profile.formatProductsFilter(opt.products || {})
+			profile.formatProductsFilter({profile}, opt.products || {})
 		]
 		if (
 			opt.accessibility &&
@@ -455,7 +451,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 				perStep: Math.round(durationPerStep),
 				ageOfReport: true, // todo: what is this?
 				jnyFltrL: [
-					profile.formatProductsFilter(opt.products || {})
+					profile.formatProductsFilter({profile}, opt.products || {})
 				],
 				trainPosMode: 'CALC' // todo: what is this? what about realtime?
 			}
@@ -490,7 +486,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 					time: profile.formatTime(profile, opt.when),
 					period: 120, // todo: what is this?
 					jnyFltrL: [
-						profile.formatProductsFilter(opt.products || {})
+						profile.formatProductsFilter({profile}, opt.products || {})
 					]
 				}
 			})

--- a/lib/default-profile.js
+++ b/lib/default-profile.js
@@ -2,6 +2,14 @@
 
 const request = require('../lib/request')
 
+const formatStationBoardReq = require('../format/station-board-req')
+const formatLocationsReq = require('../format/locations-req')
+const formatStopReq = require('../format/stop-req')
+const formatNearbyReq = require('../format/nearby-req')
+const formatTripReq = require('../format/trip-req')
+const formatRadarReq = require('../format/radar-req')
+const formatReachableFromReq = require('../format/reachable-from-req')
+
 const parseDateTime = require('../parse/date-time')
 const parsePlatform = require('../parse/platform')
 const parseProductsBitmask = require('../parse/products-bitmask')
@@ -44,6 +52,13 @@ const defaultProfile = {
 	addChecksum: false,
 	addMicMac: false,
 
+	formatStationBoardReq,
+	formatLocationsReq,
+	formatStopReq,
+	formatNearbyReq,
+	formatTripReq,
+	formatRadarReq,
+	formatReachableFromReq,
 	transformJourneysQuery: id,
 
 	parseDateTime,

--- a/lib/default-profile.js
+++ b/lib/default-profile.js
@@ -2,6 +2,7 @@
 
 const parseDateTime = require('../parse/date-time')
 const parsePlatform = require('../parse/platform')
+const parseProductsBitmask = require('../parse/products-bitmask')
 const parseIcon = require('../parse/icon')
 const parseWhen = require('../parse/when')
 const parseDeparture = require('../parse/departure')
@@ -44,6 +45,7 @@ const defaultProfile = {
 
 	parseDateTime,
 	parsePlatform,
+	parseProductsBitmask,
 	parseIcon,
 	parseWhen,
 	parseDeparture,
@@ -51,7 +53,7 @@ const defaultProfile = {
 	parseJourneyLeg,
 	parseJourney,
 	parseLine,
-	parseStationName: id,
+	parseStationName: (_, name) => name,
 	parseLocation,
 	parseCommon,
 	parsePolyline,

--- a/lib/default-profile.js
+++ b/lib/default-profile.js
@@ -26,6 +26,7 @@ const formatAddress = require('../format/address')
 const formatCoord = require('../format/coord')
 const formatDate = require('../format/date')
 const formatLocationFilter = require('../format/location-filter')
+const formatProductsFilter = require('../format/products-filter')
 const formatPoi = require('../format/poi')
 const formatStation = require('../format/station')
 const formatTime = require('../format/time')
@@ -70,6 +71,7 @@ const defaultProfile = {
 	formatCoord,
 	formatDate,
 	formatLocationFilter,
+	formatProductsFilter,
 	formatPoi,
 	formatStation,
 	formatTime,

--- a/lib/default-profile.js
+++ b/lib/default-profile.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const request = require('../lib/request')
+
 const parseDateTime = require('../parse/date-time')
 const parsePlatform = require('../parse/platform')
 const parseProductsBitmask = require('../parse/products-bitmask')
@@ -34,12 +36,12 @@ const filters = require('../format/filters')
 const id = (ctx, x) => x
 
 const defaultProfile = {
+	request,
+	transformReqBody: id,
+	transformReq: id,
 	salt: null,
 	addChecksum: false,
 	addMicMac: false,
-
-	transformReqBody: id,
-	transformReq: id,
 
 	transformJourneysQuery: id,
 

--- a/lib/default-profile.js
+++ b/lib/default-profile.js
@@ -31,7 +31,7 @@ const formatLocation = require('../format/location')
 const formatRectangle = require('../format/rectangle')
 const filters = require('../format/filters')
 
-const id = x => x
+const id = (ctx, x) => x
 
 const defaultProfile = {
 	salt: null,

--- a/lib/profile-hooks.js
+++ b/lib/profile-hooks.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// For any type of "thing to parse", there's >=1 parse functions.
+// By composing custom parse function(s) with the default ones, one
+// can customize the behaviour of hafas-client. Profiles extensively
+// use this mechanism.
+
+// Each parse function has the following signature:
+// ({opt, profile, common, res}, ...raw) => newParsed
+
+// Compose a new/custom parse function with the old/existing parse
+// function, so that the new fn will be called with the output of the
+// old fn.
+const parseHook = (oldParse, newParse) => {
+	return (ctx, ...args) => {
+		return newParse({
+			...ctx,
+			parsed: oldParse({...ctx, parsed: {}}, ...args)
+		}, ...args)
+	}
+}
+
+module.exports = {
+	parseHook
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -30,14 +30,16 @@ const addErrorInfo = (err, errorCode, errorText) => {
 	}
 }
 
-const request = (profile, userAgent, opt, data) => {
-	const body = profile.transformReqBody({
+const request = (ctx, userAgent, reqData) => {
+	const {profile, opt} = ctx
+
+	const body = profile.transformReqBody(ctx, {
 		lang: opt.language || 'en', // todo: is it `eng` actually?
-		svcReqL: [data]
+		svcReqL: [reqData]
 	})
 	if (DEBUG) console.error(JSON.stringify(body))
 
-	const req = profile.transformReq({
+	const req = profile.transformReq(ctx, {
 		method: 'post',
 		// todo: CORS? referrer policy?
 		body: JSON.stringify(body),
@@ -106,7 +108,11 @@ const request = (profile, userAgent, opt, data) => {
 			throw err
 		}
 
-		return profile.parseCommon(profile, opt, b.svcResL[0].res)
+		const res = b.svcResL[0].res
+		return {
+			res,
+			common: profile.parseCommon({...ctx, res})
+		}
 	})
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -79,7 +79,7 @@ const request = (ctx, userAgent, reqData) => {
 	// Async stack traces are not supported everywhere yet, so we create our own.
 	const err = new Error()
 	err.isHafasError = true // todo: rename to `isHafasClientError`
-	err.request = body
+	err.request = req.body // todo: commit as bugfix
 	err.url = url
 	captureStackTrace(err)
 

--- a/lib/validate-profile.js
+++ b/lib/validate-profile.js
@@ -3,6 +3,8 @@
 const types = {
 	locale: 'string',
 	timezone: 'string',
+
+	request: 'function',
 	transformReq: 'function',
 	transformReqBody: 'function',
 	transformJourneysQuery: 'function',

--- a/lib/validate-profile.js
+++ b/lib/validate-profile.js
@@ -31,6 +31,7 @@ const types = {
 	formatCoord: 'function',
 	formatDate: 'function',
 	formatLocationFilter: 'function',
+	formatProductsFilter: 'function',
 	formatPoi: 'function',
 	formatStation: 'function',
 	formatTime: 'function',

--- a/lib/validate-profile.js
+++ b/lib/validate-profile.js
@@ -7,6 +7,14 @@ const types = {
 	request: 'function',
 	transformReq: 'function',
 	transformReqBody: 'function',
+
+	formatStationBoardReq: 'function',
+	formatLocationsReq: 'function',
+	formatStopReq: 'function',
+	formatNearbyReq: 'function',
+	formatTripReq: 'function',
+	formatRadarReq: 'function',
+	formatReachableFromReq: 'function',
 	transformJourneysQuery: 'function',
 
 	products: 'array',

--- a/p/cfl/index.js
+++ b/p/cfl/index.js
@@ -2,7 +2,7 @@
 
 const products = require('./products')
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	body.client = {
 		type: 'IPH',
 		id: 'HAFAS',

--- a/p/cmta/index.js
+++ b/p/cmta/index.js
@@ -2,7 +2,7 @@
 
 const products = require('./products')
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	body.client = {
 		type: 'IPH',
 		id: 'CMTA',

--- a/p/db/index.js
+++ b/p/db/index.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const trim = require('lodash/trim')
+const {parseHook} = require('../../lib/profile-hooks')
 
-const _createParseArrival = require('../../parse/arrival')
-const _createParseDeparture = require('../../parse/departure')
-const _createParseJourney = require('../../parse/journey')
-const _createParseJourneyLeg = require('../../parse/journey-leg')
-const _createParseLine = require('../../parse/line')
+const _parseJourney = require('../../parse/journey')
+const _parseJourneyLeg = require('../../parse/journey-leg')
+const _parseLine = require('../../parse/line')
+const _parseArrival = require('../../parse/arrival')
+const _parseDeparture = require('../../parse/departure')
 const _parseHint = require('../../parse/hint')
 const _formatStation = require('../../format/station')
 const {bike} = require('../../format/filters')
@@ -14,7 +15,7 @@ const {bike} = require('../../format/filters')
 const products = require('./products')
 const formatLoyaltyCard = require('./loyalty-cards').format
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	const req = body.svcReqL[0] || {}
 
 	// see https://pastebin.com/qZ9WS3Cx
@@ -41,24 +42,15 @@ const parseLoadFactor = (opt, tcocL, tcocX) => {
 	return load && loadFactors[load.r] || null
 }
 
-const createParseArrOrDep = (createParse) => (profile, opt, data) => {
-	const parse = createParse(profile, opt, data)
-	const parseWithLoadFactor = (d) => {
-		const result = parse(d)
-		if (d.stbStop.dTrnCmpSX && Array.isArray(d.stbStop.dTrnCmpSX.tcocX)) {
-			const {tcocL} = data.common
-			const load = parseLoadFactor(opt, tcocL, d.stbStop.dTrnCmpSX.tcocX)
-			if (load) result.loadFactor = load
-		}
-		return result
+const parseArrOrDepWithLoadFactor = ({parsed, res, opt}, d) => {
+	if (d.stbStop.dTrnCmpSX && Array.isArray(d.stbStop.dTrnCmpSX.tcocX)) {
+		const load = parseLoadFactor(opt, res.common.tcocL || [], d.stbStop.dTrnCmpSX.tcocX)
+		if (load) parsed.loadFactor = load
 	}
-	return parseWithLoadFactor
+	return parsed
 }
 
-const createParseArrival = createParseArrOrDep(_createParseArrival)
-const createParseDeparture = createParseArrOrDep(_createParseDeparture)
-
-const transformJourneysQuery = (query, opt) => {
+const transformJourneysQuery = ({opt}, query) => {
 	const filters = query.jnyFltrL
 	if (opt.bike) filters.push(bike)
 
@@ -76,76 +68,58 @@ const transformJourneysQuery = (query, opt) => {
 	return query
 }
 
-const createParseLine = (profile, opt, data) => {
-	const parseLine = _createParseLine(profile, opt, data)
-	const parseLineWithAdditionalName = (l) => {
-		const res = parseLine(l)
-		if (l.nameS && ['bus', 'tram', 'ferry'].includes(res.product)) {
-			res.name = l.nameS
-		}
-		if (l.addName) {
-			res.additionalName = res.name
-			res.name = l.addName
-		}
-		return res
+const parseLineWithAdditionalName = ({parsed}, l) => {
+	if (l.nameS && ['bus', 'tram', 'ferry'].includes(l.product)) {
+		parsed.name = l.nameS
 	}
-	return parseLineWithAdditionalName
+	if (l.addName) {
+		parsed.additionalName = parsed.name
+		parsed.name = l.addName
+	}
+	return parsed
 }
 
-const createParseJourney = (profile, opt, data) => {
-	const parseJourney = _createParseJourney(profile, opt, data)
-
-	// todo: j.sotRating, j.conSubscr, j.isSotCon, j.showARSLink, k.sotCtxt
-	// todo: j.conSubscr, j.showARSLink, j.useableTime
-	const parseJourneyWithPrice = (j) => {
-		const res = parseJourney(j)
-
-		res.price = null
-		// todo: find cheapest, find discounts
-		// todo: write a parser like vbb-parse-ticket
-		// [ {
-		// 	prc: 15000,
-		// 	isFromPrice: true,
-		// 	isBookable: true,
-		// 	isUpsell: false,
-		// 	targetCtx: 'D',
-		// 	buttonText: 'To offer selection'
-		// } ]
-		if (
-			j.trfRes &&
-			Array.isArray(j.trfRes.fareSetL) &&
-			j.trfRes.fareSetL[0] &&
-			Array.isArray(j.trfRes.fareSetL[0].fareL) &&
-			j.trfRes.fareSetL[0].fareL[0]
-		) {
-			const tariff = j.trfRes.fareSetL[0].fareL[0]
-			if (tariff.prc >= 0) { // wat
-				res.price = {
-					amount: tariff.prc / 100,
-					currency: 'EUR',
-					hint: null
-				}
+// todo: sotRating, conSubscr, isSotCon, showARSLink, sotCtxt
+// todo: conSubscr, showARSLink, useableTime
+const parseJourneyWithPrice = ({parsed}, raw) => {
+	parsed.price = null
+	// todo: find cheapest, find discounts
+	// todo: write a parser like vbb-parse-ticket
+	// [ {
+	// 	prc: 15000,
+	// 	isFromPrice: true,
+	// 	isBookable: true,
+	// 	isUpsell: false,
+	// 	targetCtx: 'D',
+	// 	buttonText: 'To offer selection'
+	// } ]
+	if (
+		raw.trfRes &&
+		Array.isArray(raw.trfRes.fareSetL) &&
+		raw.trfRes.fareSetL[0] &&
+		Array.isArray(raw.trfRes.fareSetL[0].fareL) &&
+		raw.trfRes.fareSetL[0].fareL[0]
+	) {
+		const tariff = raw.trfRes.fareSetL[0].fareL[0]
+		if (tariff.prc >= 0) { // wat
+			parsed.price = {
+				amount: tariff.prc / 100,
+				currency: 'EUR',
+				hint: null
 			}
 		}
-
-		return res
 	}
 
-	return parseJourneyWithPrice
+	return parsed
 }
 
-const createParseJourneyLeg = (profile, opt, data) => {
-	const parseJourneyLeg = _createParseJourneyLeg(profile, opt, data)
-	const parseJourneyLegWithLoadFactor = (j, pt, parseStopovers) => {
-		const result = parseJourneyLeg(j, pt, parseStopovers)
-		if (pt.jny && pt.jny.dTrnCmpSX && Array.isArray(pt.jny.dTrnCmpSX.tcocX)) {
-			const {tcocL} = data.common
-			const load = parseLoadFactor(opt, tcocL, pt.jny.dTrnCmpSX.tcocX)
-			if (load) result.loadFactor = load
-		}
-		return result
+const parseJourneyLegWithLoadFactor = ({parsed, res, opt}, raw) => {
+	const tcocX = raw.jny && raw.jny.dTrnCmpSX && raw.jny.dTrnCmpSX.tcocX
+	if (Array.isArray(tcocX) && Array.isArray(res.tcocL)) {
+		const load = parseLoadFactor(opt, res.tcocL, tcocX)
+		if (load) parsed.loadFactor = load
 	}
-	return parseJourneyLegWithLoadFactor
+	return parsed
 }
 
 // todo:
@@ -349,20 +323,20 @@ const codesByText = Object.assign(Object.create(null), {
 	'platform change': 'changed platform', // todo: use dash, German variant
 })
 
-const parseHint = (profile, h, icons) => {
-	if (h.type === 'A') {
-		const hint = hintsByCode[h.code && h.code.trim().toLowerCase()]
+const parseHintByCode = ({parsed}, raw) => {
+	if (raw.type === 'A') {
+		const hint = hintsByCode[raw.code && raw.code.trim().toLowerCase()]
 		if (hint) {
-			return Object.assign({text: h.txtN}, hint)
+			return Object.assign({text: raw.txtN}, hint)
 		}
 	}
 
-	const res = _parseHint(profile, h, icons)
-	if (res && h.txtN) {
-		const text = trim(h.txtN.toLowerCase(), ' ()')
-		if (codesByText[text]) res.code = codesByText[text]
+	if (parsed && raw.txtN) {
+		const text = trim(raw.txtN.toLowerCase(), ' ()')
+		if (codesByText[text]) parsed.code = codesByText[text]
 	}
-	return res
+
+	return parsed
 }
 
 const isIBNR = /^\d{6,}$/
@@ -387,12 +361,12 @@ const dbProfile = {
 	products: products,
 
 	// todo: parseLocation
-	parseJourney: createParseJourney,
-	parseJourneyLeg: createParseJourneyLeg,
-	parseLine: createParseLine,
-	parseArrival: createParseArrival,
-	parseDeparture: createParseDeparture,
-	parseHint,
+	parseJourney: parseHook(_parseJourney, parseJourneyWithPrice),
+	parseJourneyLeg: parseHook(_parseJourneyLeg, parseJourneyLegWithLoadFactor),
+	parseLine: parseHook(_parseLine, parseLineWithAdditionalName),
+	parseArrival: parseHook(_parseArrival, parseArrOrDepWithLoadFactor),
+	parseDeparture: parseHook(_parseDeparture, parseArrOrDepWithLoadFactor),
+	parseHint: parseHook(_parseHint, parseHintByCode),
 
 	formatStation,
 

--- a/p/hvv/index.js
+++ b/p/hvv/index.js
@@ -2,7 +2,7 @@
 
 const products = require('./products')
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	body.client = {type: 'AND', id: 'HVV', name: 'HVVPROD_ADHOC', v: '4020100'}
 	body.ext = 'HVV.1'
 	body.ver = '1.16'

--- a/p/insa/index.js
+++ b/p/insa/index.js
@@ -2,7 +2,7 @@
 
 const products = require('./products')
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	body.client = {
 		type: 'IPH',
 		id: 'NASA',

--- a/p/nvv/index.js
+++ b/p/nvv/index.js
@@ -2,7 +2,7 @@
 
 const products = require('./products')
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	body.client = {
 		type: 'IPH',
 		id: 'NVV',

--- a/p/saarfahrplan/index.js
+++ b/p/saarfahrplan/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
-const _createParseMovement = require('../../parse/movement')
+const {parseHook} = require('../../lib/profile-hooks')
+
+const _parseMovement = require('../../parse/movement')
 const products = require('./products')
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	body.client = {
 		type: 'AND',
 		id: 'ZPS-SAAR',
@@ -18,15 +20,10 @@ const transformReqBody = (body) => {
 	return body
 }
 
-const createParseMovement = (profile, opt, data) => {
-	const _parseMovement = _createParseMovement(profile, opt, data)
-	const parseMovement = (m) => {
-		const res = _parseMovement(m)
-		// filter out empty stopovers
-		res.nextStopovers = res.nextStopovers.filter(st => !!st.stop)
-		return res
-	}
-	return parseMovement
+const fixMovement = ({parsed}, m) => {
+	// filter out empty stopovers
+	parsed.nextStopovers = parsed.nextStopovers.filter(st => !!st.stop)
+	return parsed
 }
 
 const saarfahrplanProfile = {
@@ -41,7 +38,7 @@ const saarfahrplanProfile = {
 
 	products: products,
 
-	parseMovement: createParseMovement,
+	parseMovement: parseHook(_parseMovement, fixMovement),
 
 	departuresGetPasslist: false,
 	departuresStbFltrEquiv: false,

--- a/p/sbahn-muenchen/index.js
+++ b/p/sbahn-muenchen/index.js
@@ -2,7 +2,7 @@
 
 const products = require('./products')
 
-const transformReqBody = (body) => {
+const transformReqBody = (ctx, body) => {
 	body.client = {type: 'IPH', id: 'DB-REGIO-MVV', name: 'MuenchenNavigator', v: '5010100'}
 	body.ext = 'DB.R15.12.a'
 	body.ver = '1.18'

--- a/parse/arrival-or-departure.js
+++ b/parse/arrival-or-departure.js
@@ -10,22 +10,26 @@ const DEPARTURE = 'd'
 // todo: what is d.jny.dirFlg?
 // todo: d.stbStop.dProgType/d.stbStop.aProgType
 
-const createParseArrOrDep = (profile, opt, data, prefix) => {
+const createParseArrOrDep = (prefix) => {
 	if (prefix !== ARRIVAL && prefix !== DEPARTURE) throw new Error('invalid prefix')
 
-	const parseArrOrDep = (d) => {
+	const parseArrOrDep = (ctx, d) => { // d = raw arrival/departure
+		const {profile, opt} = ctx
+
 		const tPlanned = d.stbStop[prefix + 'TimeS']
 		const tPrognosed = d.stbStop[prefix + 'TimeR']
 		const tzOffset = d.stbStop[prefix + 'TZOffset'] || null
 		const cancelled = !!d.stbStop[prefix + 'Cncl']
+		const plPlanned = d.stbStop[prefix + 'PlatfS']
+		const plPrognosed = d.stbStop[prefix + 'PlatfR']
 
 		const res = {
 			tripId: d.jid,
 			stop: d.stbStop.location || null,
-			...parseWhen(profile, d.date, tPlanned, tPrognosed, tzOffset, cancelled),
-			...parsePlatform(profile, d.stbStop[prefix + 'PlatfS'], d.stbStop[prefix + 'PlatfR'], cancelled),
+			...profile.parseWhen(ctx, d.date, tPlanned, tPrognosed, tzOffset, cancelled),
+			...profile.parsePlatform(ctx, plPlanned, plPrognosed, cancelled),
 			// todo: for arrivals, this is the *origin*, not the *direction*
-			direction: prefix === DEPARTURE && d.dirTxt && profile.parseStationName(d.dirTxt) || null,
+			direction: prefix === DEPARTURE && d.dirTxt && profile.parseStationName(ctx, d.dirTxt) || null,
 			line: d.line || null,
 			remarks: []
 		}
@@ -43,9 +47,10 @@ const createParseArrOrDep = (profile, opt, data, prefix) => {
 		}
 
    		if (opt.stopovers && Array.isArray(d.stopL)) {
-  			const parse = profile.parseStopover(profile, opt, data, d.date)
   			// Filter stations the train passes without stopping, as this doesn't comply with FPTF (yet).
-  			const stopovers = d.stopL.map(parse).filter(st => !st.passBy)
+  			const stopovers = d.stopL
+  			.map(st => profile.parseStopover(ctx, st, d.date))
+  			.filter(st => !st.passBy)
   			if (prefix === ARRIVAL) res.previousStopovers = stopovers
 			else if (prefix === DEPARTURE) res.nextStopovers = stopovers
   		}

--- a/parse/arrival.js
+++ b/parse/arrival.js
@@ -3,8 +3,6 @@
 const createParseArrOrDep = require('./arrival-or-departure')
 
 const ARRIVAL = 'a'
-const createParseArrival = (profile, opt, data) => {
-	return createParseArrOrDep(profile, opt, data, ARRIVAL)
-}
+const parseArrival = createParseArrOrDep(ARRIVAL)
 
-module.exports = createParseArrival
+module.exports = parseArrival

--- a/parse/common.js
+++ b/parse/common.js
@@ -3,102 +3,103 @@
 const get = require('lodash/get')
 const findInTree = require('../lib/find-in-tree')
 
-const parseCommonData = (profile, opt, res) => {
+const parseCommonData = (_ctx) => {
+	const {profile, opt, res} = _ctx
 	const c = res.common || {}
 
-	res.operators = []
+	const common = {}
+	const ctx = {..._ctx, common}
+
+	common.operators = []
 	if (Array.isArray(c.opL)) {
-		res.operators = c.opL.map(op => profile.parseOperator(profile, op))
+		common.operators = c.opL.map(op => profile.parseOperator(ctx, op))
 		findInTree(res, '**.oprX', (idx, parent) => {
-			if ('number' === typeof idx) parent.operator = res.operators[idx]
+			if ('number' === typeof idx) parent.operator = common.operators[idx]
 		})
 	}
 
-	res.icons = []
+	common.icons = []
 	if (Array.isArray(c.icoL)) {
-		res.icons = c.icoL.map(icon => profile.parseIcon(profile, icon))
+		common.icons = c.icoL.map(icon => profile.parseIcon(ctx, icon))
 		findInTree(res, '**.icoX', (idx, parent) => {
-			if ('number' === typeof idx) parent.icon = res.icons[idx]
+			if ('number' === typeof idx) parent.icon = common.icons[idx]
 		})
 	}
 
-	res.lines = []
+	common.lines = []
 	if (Array.isArray(c.prodL)) {
-		const parse = profile.parseLine(profile, opt, res)
-		res.lines = c.prodL.map(parse)
+		common.lines = c.prodL.map(l => profile.parseLine(ctx, l))
 
 		findInTree(res, '**.prodX', (idx, parent) => {
-			if ('number' === typeof idx) parent.line = res.lines[idx]
+			if ('number' === typeof idx) parent.line = common.lines[idx]
 		})
 		findInTree(res, '**.pRefL', (idxs, parent) => {
-			parent.lines = idxs.filter(idx => !!res.lines[idx]).map(idx => res.lines[idx])
+			parent.lines = idxs.filter(idx => !!common.lines[idx]).map(idx => common.lines[idx])
 		})
 		// todo
-		// **.dep.dProdX: departureLine -> res.lines[idx]
-		// **.arr.aProdX: arrivalLine -> res.lines[idx]
+		// **.dep.dProdX: departureLine -> common.lines[idx]
+		// **.arr.aProdX: arrivalLine -> common.lines[idx]
 	}
 
-	res.locations = []
+	common.locations = []
 	if (Array.isArray(c.locL)) {
-		const parse = loc => profile.parseLocation(profile, opt, res, loc)
-		res.locations = c.locL.map(parse)
+		common.locations = c.locL.map(loc => profile.parseLocation(ctx, loc))
 
-		for (let i = 0; i < res.locations.length; i++) {
+		for (let i = 0; i < common.locations.length; i++) {
 			const raw = c.locL[i]
-			const loc = res.locations[i]
+			const loc = common.locations[i]
 			if ('number' === typeof raw.mMastLocX) {
-				loc.station = Object.assign({}, res.locations[raw.mMastLocX])
+				loc.station = Object.assign({}, common.locations[raw.mMastLocX])
 				loc.station.type = 'station'
 			} else if (raw.isMainMast) loc.type = 'station'
 		}
 
 		// todo: correct props?
 		findInTree(res, '**.locX', (idx, parent) => {
-			if ('number' === typeof idx) parent.location = res.locations[idx]
+			if ('number' === typeof idx) parent.location = common.locations[idx]
 		})
 		findInTree(res, '**.ani.fLocX', (idxs, parent) => {
-			parent.fromLocations = idxs.map(idx => res.locations[idx])
+			parent.fromLocations = idxs.map(idx => common.locations[idx])
 		})
 		findInTree(res, '**.ani.tLocX', (idxs, parent) => {
-			parent.toLocations = idxs.map(idx => res.locations[idx])
+			parent.toLocations = idxs.map(idx => common.locations[idx])
 		})
 		findInTree(res, '**.fLocX', (idx, parent) => {
-			if ('number' === typeof idx) parent.fromLocation = res.locations[idx]
+			if ('number' === typeof idx) parent.fromLocation = common.locations[idx]
 		})
 		findInTree(res, '**.tLocX', (idx, parent) => {
-			if ('number' === typeof idx) parent.toLocation = res.locations[idx]
+			if ('number' === typeof idx) parent.toLocation = common.locations[idx]
 		})
 	}
 
-	res.hints = []
+	common.hints = []
 	if (opt.remarks && Array.isArray(c.remL)) {
-		res.hints = c.remL.map(hint => profile.parseHint(profile, hint, {...c, ...res}))
+		common.hints = c.remL.map(hint => profile.parseHint(ctx, hint))
 		findInTree(res, '**.remX', (idx, parent) => {
-			if ('number' === typeof idx) parent.hint = res.hints[idx]
+			if ('number' === typeof idx) parent.hint = common.hints[idx]
 		})
 	}
-	res.warnings = []
+	common.warnings = []
 	if (opt.remarks && Array.isArray(c.himL)) {
-		res.warnings = c.himL.map(w => profile.parseWarning(profile, w, {...c, ...res}))
+		common.warnings = c.himL.map(w => profile.parseWarning(ctx, w))
 		findInTree(res, '**.himX', (idx, parent) => {
-			if ('number' === typeof idx) parent.warning = res.warnings[idx]
+			if ('number' === typeof idx) parent.warning = common.warnings[idx]
 		})
 	}
 
-	res.polylines = []
+	common.polylines = []
 	if (opt.polylines && Array.isArray(c.polyL)) {
-		const parse = profile.parsePolyline(profile, opt, res)
-		res.polylines = c.polyL.map(parse)
+		common.polylines = c.polyL.map(p => profile.parsePolyline(ctx, p))
 		// todo: **.ani.poly -> parsePolyline()
 
 		findInTree(res, '**.polyG.polyXL', (idxs, _, path) => {
-			const idx = idxs.find(idx => !!res.polylines[idx]) // find any given polyline
+			const idx = idxs.find(idx => !!common.polylines[idx]) // find any given polyline
 			const jny = get(res, path.slice(0, -2))
-			jny.polyline = res.polylines[idx]
+			jny.polyline = common.polylines[idx]
 		})
 	}
 
-	return res
+	return common
 }
 
 module.exports = parseCommonData

--- a/parse/date-time.js
+++ b/parse/date-time.js
@@ -4,8 +4,7 @@ const {DateTime, FixedOffsetZone, IANAZone} = require('luxon')
 
 const timezones = new WeakMap()
 
-// todo: change to `(profile) => (date, time) => {}`
-const parseDateTime = (profile, date, time, tzOffset = null, timestamp = false) => {
+const parseDateTime = ({profile}, date, time, tzOffset = null, timestamp = false) => {
 	const pDate = [date.substr(-8, 4), date.substr(-4, 2), date.substr(-2, 2)]
 	if (!pDate[0] || !pDate[1] || !pDate[2]) {
 		throw new Error('invalid date format: ' + date)

--- a/parse/departure.js
+++ b/parse/departure.js
@@ -3,8 +3,6 @@
 const createParseArrOrDep = require('./arrival-or-departure')
 
 const DEPARTURE = 'd'
-const createParseDeparture = (profile, opt, data) => {
-	return createParseArrOrDep(profile, opt, data, DEPARTURE)
-}
+const parseDeparture = createParseArrOrDep(DEPARTURE)
 
-module.exports = createParseDeparture
+module.exports = parseDeparture

--- a/parse/hint.js
+++ b/parse/hint.js
@@ -4,7 +4,6 @@ const codesByIcon = Object.assign(Object.create(null), {
 	cancel: 'cancelled'
 })
 
-// todo: is passing in profile necessary?
 // todo: pass in tag list from hint reference, e.g.:
 // "tagL": [
 // 	"RES_JNY_H3" // H3 = level 3 heading? shown on overview
@@ -13,7 +12,7 @@ const codesByIcon = Object.assign(Object.create(null), {
 // 	"RES_JNY_DTL" // only shown in journey detail
 // ]
 // todo: https://github.com/public-transport/hafas-client/issues/5
-const parseHint = (profile, h, _) => {
+const parseHint = (ctx, h) => {
 	// todo: C
 
 	const text = h.txtN && h.txtN.trim() || ''

--- a/parse/icon.js
+++ b/parse/icon.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const parseIcon = (profile, i) => {
+const parseIcon = (ctx, i) => {
 	const res = {
 		type: i.res || null,
 		title: i.text || i.txt || i.txtS || null

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -32,120 +32,116 @@ const applyRemarks = (leg, refs) => {
 	}
 }
 
-const createParseJourneyLeg = (profile, opt, data) => {
-	// todo: pt.status, pt.isPartCncl
-	// todo: pt.isRchbl, pt.chRatingRT, pt.chgDurR, pt.minChg
-	// todo: pt.dep.dProgType, pt.arr.dProgType
-	// todo: what is pt.jny.dirFlg?
-	// todo: what is pt.recState?
-	// todo: what is `sty: 'UNDEF'`?
-	// todo: pt.prodL
-	// todo: pt.parJnyL (list of coupled trains)
+// todo: pt.status, pt.isPartCncl
+// todo: pt.isRchbl, pt.chRatingRT, pt.chgDurR, pt.minChg
+// todo: pt.dep.dProgType, pt.arr.dProgType
+// todo: what is pt.jny.dirFlg?
+// todo: what is pt.recState?
+// todo: what is `sty: 'UNDEF'`?
+// todo: pt.prodL
+// todo: pt.parJnyL (list of coupled trains)
+// todo: pt.planrtTS
 
-	// j = journey, pt = part
-	// todo: pt.planrtTS
-	const parseJourneyLeg = (j, pt, parseStopovers = true) => {
-		const res = {
-			origin: clone(pt.dep.location) || null,
-			destination: clone(pt.arr.location)
-		}
+const parseJourneyLeg = (ctx, pt, date) => { // pt = raw leg
+	const {profile, opt} = ctx
 
-		const arr = parseWhen(profile, j.date, pt.arr.aTimeS, pt.arr.aTimeR, pt.arr.aTZOffset, pt.arr.aCncl)
-		res.arrival = arr.when
-		res.plannedArrival = arr.plannedWhen
-		res.arrivalDelay = arr.delay
-		if (arr.prognosedWhen) res.prognosedArrival = arr.prognosedWhen
-
-		const dep = parseWhen(profile, j.date, pt.dep.dTimeS, pt.dep.dTimeR, pt.dep.dTZOffset, pt.dep.dCncl)
-		res.departure = dep.when
-		res.plannedDeparture = dep.plannedWhen
-		res.departureDelay = dep.delay
-		if (dep.prognosedWhen) res.prognosedDeparture = dep.prognosedWhen
-
-		if (pt.jny) {
-			res.reachable = !!pt.jny.isRchbl
-		}
-
-		if (pt.jny && pt.jny.polyline) {
-			res.polyline = pt.jny.polyline || null
-		}
-
-		if (pt.type === 'WALK' || pt.type === 'TRSF') {
-			res.public = true
-			res.walking = true
-			res.distance = pt.gis && pt.gis.dist || null
-			if (pt.type === 'TRSF') res.transfer = true
-
-			// https://gist.github.com/derhuerst/426d4b95aeae701843b1e9c23105b8d4#file-tripsearch-2018-12-05-http-L4207-L4229
-			if (opt.remarks && Array.isArray(pt.gis.msgL)) {
-				applyRemarks(res, pt.gis.msgL)
-			}
-		} else if (pt.type === 'JNY') {
-			// todo: pull `public` value from `profile.products`
-			res.tripId = pt.jny.jid
-			res.line = pt.jny.line || null
-			res.direction = pt.jny.dirTxt && profile.parseStationName(pt.jny.dirTxt) || null
-
-			const arrPl = parsePlatform(profile, pt.arr.aPlatfS, pt.arr.aPlatfR, pt.arr.aCncl)
-			res.arrivalPlatform = arrPl.platform
-			res.plannedArrivalPlatform = arrPl.plannedPlatform
-			if (arrPl.prognosedPlatform) res.prognosedArrivalPlatform = arrPl.prognosedPlatform
-
-			const depPl = parsePlatform(profile, pt.dep.dPlatfS, pt.dep.dPlatfR, pt.dep.dCncl)
-			res.departurePlatform = depPl.platform
-			res.plannedDeparturePlatform = depPl.plannedPlatform
-			if (depPl.prognosedPlatform) res.prognosedDeparturePlatform = depPl.prognosedPlatform
-
-			if (parseStopovers && pt.jny.stopL) {
-				const parse = profile.parseStopover(profile, opt, data, j.date)
-				const stopL = pt.jny.stopL
-				res.stopovers = stopL.map(parse)
-
-				if (opt.remarks && Array.isArray(pt.jny.msgL)) {
-					// todo: apply leg-wide remarks if `parseStopovers` is false
-					applyRemarks(res, pt.jny.msgL)
-				}
-
-				// filter stations the train passes without stopping, as this doesn't comply with fptf (yet)
-				res.stopovers = res.stopovers.filter((x) => !x.passBy)
-			}
-
-			const freq = pt.jny.freq || {}
-			// todo: expose `res.cycle` even if only one field exists (breaking)
-			if (freq.minC && freq.maxC) {
-				res.cycle = {
-					min: freq.minC * 60,
-					max: freq.maxC * 60
-				}
-				// nr of connections in this frequency, from now on
-				if (freq.numC) res.cycle.nr = freq.numC
-			}
-
-			if (freq.jnyL) {
-				const parseAlternative = (a) => {
-					// todo: parse this just like a `leg` (breaking)
-					// todo: parse `a.stopL`, `a.ctxRecon`, `a.msgL`
-					const st0 = a.stopL[0] || {}
-					return {
-						tripId: a.jid,
-						line: a.line || null,
-						direction: a.dirTxt || null,
-						...parseWhen(profile, j.date, st0.dTimeS, st0.dTimeR, st0.dTZOffset, st0.dCncl)
-					}
-				}
-				res.alternatives = freq.jnyL.map(parseAlternative)
-			}
-		}
-
-		if (pt.arr.aCncl || pt.dep.dCncl) {
-			res.cancelled = true
-			Object.defineProperty(res, 'canceled', {value: true})
-		}
-
-		return res
+	const res = {
+		origin: clone(pt.dep.location) || null,
+		destination: clone(pt.arr.location)
 	}
 
-	return parseJourneyLeg
+	const arr = profile.parseWhen(ctx, date, pt.arr.aTimeS, pt.arr.aTimeR, pt.arr.aTZOffset, pt.arr.aCncl)
+	res.arrival = arr.when
+	res.plannedArrival = arr.plannedWhen
+	res.arrivalDelay = arr.delay
+	if (arr.prognosedWhen) res.prognosedArrival = arr.prognosedWhen
+
+	const dep = profile.parseWhen(ctx, date, pt.dep.dTimeS, pt.dep.dTimeR, pt.dep.dTZOffset, pt.dep.dCncl)
+	res.departure = dep.when
+	res.plannedDeparture = dep.plannedWhen
+	res.departureDelay = dep.delay
+	if (dep.prognosedWhen) res.prognosedDeparture = dep.prognosedWhen
+
+	if (pt.jny) {
+		res.reachable = !!pt.jny.isRchbl
+	}
+
+	if (pt.jny && pt.jny.polyline) {
+		res.polyline = pt.jny.polyline || null
+	}
+
+	if (pt.type === 'WALK' || pt.type === 'TRSF') {
+		res.public = true
+		res.walking = true
+		res.distance = pt.gis && pt.gis.dist || null
+		if (pt.type === 'TRSF') res.transfer = true
+
+		// https://gist.github.com/derhuerst/426d4b95aeae701843b1e9c23105b8d4#file-tripsearch-2018-12-05-http-L4207-L4229
+		if (opt.remarks && Array.isArray(pt.gis.msgL)) {
+			applyRemarks(res, pt.gis.msgL)
+		}
+	} else if (pt.type === 'JNY') {
+		// todo: pull `public` value from `profile.products`
+		res.tripId = pt.jny.jid
+		res.line = pt.jny.line || null
+		res.direction = pt.jny.dirTxt && profile.parseStationName(ctx, pt.jny.dirTxt) || null
+
+		const arrPl = profile.parsePlatform(ctx, pt.arr.aPlatfS, pt.arr.aPlatfR, pt.arr.aCncl)
+		res.arrivalPlatform = arrPl.platform
+		res.plannedArrivalPlatform = arrPl.plannedPlatform
+		if (arrPl.prognosedPlatform) res.prognosedArrivalPlatform = arrPl.prognosedPlatform
+
+		const depPl = profile.parsePlatform(ctx, pt.dep.dPlatfS, pt.dep.dPlatfR, pt.dep.dCncl)
+		res.departurePlatform = depPl.platform
+		res.plannedDeparturePlatform = depPl.plannedPlatform
+		if (depPl.prognosedPlatform) res.prognosedDeparturePlatform = depPl.prognosedPlatform
+
+		if (opt.stopovers && pt.jny.stopL) {
+			const stopL = pt.jny.stopL
+			res.stopovers = stopL.map(s => profile.parseStopover(ctx, s, date))
+
+			if (opt.remarks && Array.isArray(pt.jny.msgL)) {
+				// todo: apply leg-wide remarks if `opt.stopovers` is false
+				applyRemarks(res, pt.jny.msgL)
+			}
+
+			// filter stations the train passes without stopping, as this doesn't comply with fptf (yet)
+			res.stopovers = res.stopovers.filter((x) => !x.passBy)
+		}
+
+		const freq = pt.jny.freq || {}
+		// todo: expose `res.cycle` even if only one field exists (breaking)
+		if (freq.minC && freq.maxC) {
+			res.cycle = {
+				min: freq.minC * 60,
+				max: freq.maxC * 60
+			}
+			// nr of connections in this frequency, from now on
+			if (freq.numC) res.cycle.nr = freq.numC
+		}
+
+		if (freq.jnyL) {
+			const parseAlternative = (a) => {
+				// todo: parse this just like a `leg` (breaking)
+				// todo: parse `a.stopL`, `a.ctxRecon`, `a.msgL`
+				const st0 = a.stopL[0] || {}
+				return {
+					tripId: a.jid,
+					line: a.line || null,
+					direction: a.dirTxt || null,
+					...profile.parseWhen(ctx, date, st0.dTimeS, st0.dTimeR, st0.dTZOffset, st0.dCncl)
+				}
+			}
+			res.alternatives = freq.jnyL.map(parseAlternative)
+		}
+	}
+
+	if (pt.arr.aCncl || pt.dep.dCncl) {
+		res.cancelled = true
+		Object.defineProperty(res, 'canceled', {value: true})
+	}
+
+	return res
 }
 
-module.exports = createParseJourneyLeg
+module.exports = parseJourneyLeg

--- a/parse/journey.js
+++ b/parse/journey.js
@@ -22,47 +22,44 @@ const parseScheduledDays = (sDaysB, year, profile) => {
 	return res
 }
 
-const createParseJourney = (profile, opt, data) => {
-	const parseLeg = profile.parseJourneyLeg(profile, opt, data)
-	// todo: c.conSubscr
-	// todo: c.trfRes x vbb-parse-ticket
-	// todo: c.sotRating, c.isSotCon, c.sotCtxt
-	// todo: c.showARSLink
-	// todo: c.useableTime
-	// todo: c.cksum
-	// todo: c.isNotRdbl
-	// todo: c.badSecRefX
-	// todo: c.bfATS, c.bfIOSTS
-	const parseJourney = (j) => {
-		const legs = j.secL.map(leg => parseLeg(j, leg))
-		const res = {
-			type: 'journey',
-			legs,
-			refreshToken: j.ctxRecon || null
-		}
+// todo: c.conSubscr
+// todo: c.trfRes x vbb-parse-ticket
+// todo: c.sotRating, c.isSotCon, c.sotCtxt
+// todo: c.showARSLink
+// todo: c.useableTime
+// todo: c.cksum
+// todo: c.isNotRdbl
+// todo: c.badSecRefX
+// todo: c.bfATS, c.bfIOSTS
+const parseJourney = (ctx, j) => { // j = raw jouney
+	const {profile, opt} = ctx
 
-		const freq = j.freq || {}
-		if (freq.minC || freq.maxC) {
-			res.cycle = {}
-			if (freq.minC) res.cycle.min = freq.minC * 60
-			if (freq.maxC) res.cycle.max = freq.maxC * 60
-			// nr of connections in this frequency, from now on
-			if (freq.numC) res.cycle.nr = freq.numC
-		}
-
-		if (opt.remarks && Array.isArray(j.msgL)) {
-			res.remarks = findRemarks(j.msgL).map(([remark]) => remark)
-		}
-
-		if (opt.scheduledDays) {
-			const year = parseInt(j.date.slice(0, 4))
-			res.scheduledDays = parseScheduledDays(j.sDays.sDaysB, year, profile)
-		}
-
-		return res
+	const legs = j.secL.map(l => profile.parseJourneyLeg(ctx, l, j.date))
+	const res = {
+		type: 'journey',
+		legs,
+		refreshToken: j.ctxRecon || null
 	}
 
-	return parseJourney
+	const freq = j.freq || {}
+	if (freq.minC || freq.maxC) {
+		res.cycle = {}
+		if (freq.minC) res.cycle.min = freq.minC * 60
+		if (freq.maxC) res.cycle.max = freq.maxC * 60
+		// nr of connections in this frequency, from now on
+		if (freq.numC) res.cycle.nr = freq.numC
+	}
+
+	if (opt.remarks && Array.isArray(j.msgL)) {
+		res.remarks = findRemarks(j.msgL).map(([remark]) => remark)
+	}
+
+	if (opt.scheduledDays) {
+		const year = parseInt(j.date.slice(0, 4))
+		res.scheduledDays = parseScheduledDays(j.sDays.sDaysB, year, profile)
+	}
+
+	return res
 }
 
-module.exports = createParseJourney
+module.exports = parseJourney

--- a/parse/line.js
+++ b/parse/line.js
@@ -2,45 +2,42 @@
 
 const slugg = require('slugg')
 
-const createParseLine = (profile, opt, _) => {
-	const byBitmask = []
-	for (let product of profile.products) {
-		for (let bitmask of product.bitmasks) {
-			byBitmask[bitmask] = product
+const parseLine = ({profile}, p) => {
+	if (!p) return null // todo: handle this upstream
+	const name = p.line || p.addName || p.name || null // wtf
+	const res = {
+		type: 'line',
+		// This is terrible, but FPTF demands an ID. Let's pray for HAFAS.
+		id: (
+			p.prodCtx && p.prodCtx.lineId && slugg(p.prodCtx.lineId.trim())
+			|| name && slugg(name.trim())
+			|| null
+		),
+		// todo: what is p.prodCtx.matchId? use as `id`? expose it.
+		fahrtNr: p.prodCtx && p.prodCtx.num || null,
+		name,
+		public: true
+	}
+	// todo: what is p.number?
+	// todo: what is p.prodCtx.catCode?
+
+	if ('cls' in p) {
+		// todo: use profile.products.find() for this
+		const byBitmask = []
+		for (let product of profile.products) {
+			for (let bitmask of product.bitmasks) {
+				byBitmask[bitmask] = product
+			}
 		}
+
+		// todo: what if `p.cls` is the sum of two bitmasks?
+		const product = byBitmask[parseInt(p.cls)]
+		res.mode = product && product.mode || null
+		res.product = product && product.id || null
 	}
 
-	// todo: p.himIdL
-	const parseLine = (p) => {
-		if (!p) return null // todo: handle this upstream
-		const name = p.line || p.addName || p.name || null // wtf
-		const res = {
-			type: 'line',
-			// This is terrible, but FPTF demands an ID. Let's pray for HAFAS.
-			id: (
-				p.prodCtx && p.prodCtx.lineId && slugg(p.prodCtx.lineId.trim())
-				|| name && slugg(name.trim())
-				|| null
-			),
-			// todo: what is p.prodCtx.matchId? use as `id`? expose it.
-			fahrtNr: p.prodCtx && p.prodCtx.num || null,
-			name,
-			public: true
-		}
-		// todo: what is p.number?
-		// todo: what is p.prodCtx.catCode?
-
-		if ('cls' in p) {
-			// todo: what if `p.cls` is the sum of two bitmasks?
-			const product = byBitmask[parseInt(p.cls)]
-			res.mode = product && product.mode || null
-			res.product = product && product.id || null
-		}
-
-		if (p.operator) res.operator = p.operator // todo: move up
-		return res
-	}
-	return parseLine
+	if (p.operator) res.operator = p.operator // todo: move up
+	return res
 }
 
-module.exports = createParseLine
+module.exports = parseLine

--- a/parse/location.js
+++ b/parse/location.js
@@ -9,7 +9,9 @@ const ADDRESS = 'A'
 const leadingZeros = /^0+/
 
 // todo: what is s.rRefL?
-const parseLocation = (profile, opt, _, l) => {
+const parseLocation = (ctx, l) => {
+	const {profile, opt} = ctx
+
 	const lid = parse(l.lid, {delimiter: '@'})
 	const res = {
 		type: 'location',
@@ -25,11 +27,11 @@ const parseLocation = (profile, opt, _, l) => {
 		const stop = {
 			type: l.isMainMast ? 'station' : 'stop',
 			id: res.id,
-			name: l.name || id.O ? profile.parseStationName(l.name || id.O) : null,
+			name: l.name || id.O ? profile.parseStationName(ctx, l.name || id.O) : null,
 			location: 'number' === typeof res.latitude ? res : null // todo: remove `.id`
 		}
 
-		if ('pCls' in l) stop.products = profile.parseProducts(l.pCls)
+		if ('pCls' in l) stop.products = profile.parseProductsBitmask(ctx, l.pCls)
 		if ('meta' in l) stop.isMeta = !!l.meta
 
 		if (opt.linesOfStops && Array.isArray(l.lines)) {

--- a/parse/movement.js
+++ b/parse/movement.js
@@ -1,53 +1,49 @@
 'use strict'
 
-const createParseMovement = (profile, opt, data) => {
-	// todo: what is m.dirGeo? maybe the speed?
-	// todo: what is m.stopL?
-	// todo: what is m.proc? wut?
-	// todo: what is m.pos?
-	// todo: what is m.ani.dirGeo[n]? maybe the speed?
-	// todo: what is m.ani.proc[n]? wut?
-	const parseMovement = (m) => {
-		const pStopover = profile.parseStopover(profile, opt, data, m.date)
+// todo: what is m.dirGeo? maybe the speed?
+// todo: what is m.stopL?
+// todo: what is m.proc? wut?
+// todo: what is m.pos?
+// todo: what is m.ani.dirGeo[n]? maybe the speed?
+// todo: what is m.ani.proc[n]? wut?
+const parseMovement = (ctx, m) => { // m = raw movement
+	const {profile, opt} = ctx
 
-		const res = {
-			direction: m.dirTxt ? profile.parseStationName(m.dirTxt) : null,
-			tripId: m.jid || null,
-			line: m.line || null,
-			location: m.pos ? {
-				type: 'location',
-				latitude: m.pos.y / 1000000,
-				longitude: m.pos.x / 1000000
-			} : null,
-			// todo: stopL[0] is the first of the trip! -> filter out
-			nextStopovers: m.stopL.map(pStopover),
-			frames: []
-		}
-
-		if (m.ani) {
-			if (Array.isArray(m.ani.mSec)) {
-				for (let i = 0; i < m.ani.mSec.length; i++) {
-					res.frames.push({
-						origin: m.ani.fromLocations[i] || null,
-						destination: m.ani.toLocations[i] || null,
-						t: m.ani.mSec[i]
-					})
-				}
-			}
-
-			if (opt.polylines) {
-				if (m.ani.poly) {
-					const parse = profile.parsePolyline(profile, opt, data)
-					res.polyline = parse(m.ani.poly)
-				} else if (m.ani.polyline) {
-					res.polyline = m.ani.polyline
-				}
-			}
-		}
-
-		return res
+	const res = {
+		direction: m.dirTxt ? profile.parseStationName(ctx, m.dirTxt) : null,
+		tripId: m.jid || null,
+		line: m.line || null,
+		location: m.pos ? {
+			type: 'location',
+			latitude: m.pos.y / 1000000,
+			longitude: m.pos.x / 1000000
+		} : null,
+		// todo: stopL[0] is the first of the trip! -> filter out
+		nextStopovers: m.stopL.map(s => profile.parseStopover(ctx, s, m.date)),
+		frames: []
 	}
-	return parseMovement
+
+	if (m.ani) {
+		if (Array.isArray(m.ani.mSec)) {
+			for (let i = 0; i < m.ani.mSec.length; i++) {
+				res.frames.push({
+					origin: m.ani.fromLocations[i] || null,
+					destination: m.ani.toLocations[i] || null,
+					t: m.ani.mSec[i]
+				})
+			}
+		}
+
+		if (opt.polylines) {
+			if (m.ani.poly) {
+				res.polyline = profile.parsePolyline(ctx, m.ani.poly)
+			} else if (m.ani.polyline) {
+				res.polyline = m.ani.polyline
+			}
+		}
+	}
+
+	return res
 }
 
-module.exports = createParseMovement
+module.exports = parseMovement

--- a/parse/nearby.js
+++ b/parse/nearby.js
@@ -6,9 +6,8 @@
 // todo: what is s.wt?
 // todo: what is s.dur?
 
-// todo: [breaking] change to createParseNearby(profile, data) => (n) => nearby
-const parseNearby = (profile, opt, data, n) => {
-	const res = profile.parseLocation(profile, opt, data, n)
+const parseNearby = (ctx, n) => { // n = raw nearby location
+	const res = ctx.profile.parseLocation(ctx, n)
 	res.distance = n.dist
 	return res
 }

--- a/parse/operator.js
+++ b/parse/operator.js
@@ -2,7 +2,7 @@
 
 const slugg = require('slugg')
 
-const parseOperator = (profile, a) => {
+const parseOperator = (ctx, a) => {
 	const name = a.name && a.name.trim()
 	if (!name) return null
 	return {

--- a/parse/platform.js
+++ b/parse/platform.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const parsePlatform = (profile, platfS, platfR, cncl = false) => {
+const parsePlatform = (ctx, platfS, platfR, cncl = false) => {
 	let planned = platfS || null
 	let prognosed = platfR || null
 

--- a/parse/polyline.js
+++ b/parse/polyline.js
@@ -3,50 +3,47 @@
 const {toGeoJSON} = require('@mapbox/polyline')
 const distance = require('gps-distance')
 
-const createParsePolyline = (profile, opt, _) => {
-	// todo: what is p.delta?
-	// todo: what is p.type?
-	// todo: what is p.crdEncS?
-	// todo: what is p.crdEncF?
-	const parsePolyline = (p) => {
-		const shape = toGeoJSON(p.crdEncYX)
-		if (shape.coordinates.length === 0) return null
+// todo: what is p.delta?
+// todo: what is p.type?
+// todo: what is p.crdEncS?
+// todo: what is p.crdEncF?
+const parsePolyline = (ctx, p) => { // p = raw polyline
+	const shape = toGeoJSON(p.crdEncYX)
+	if (shape.coordinates.length === 0) return null
 
-		const res = shape.coordinates.map(crd => ({
-			type: 'Feature',
-			properties: {},
-			geometry: {
-				type: 'Point',
-				coordinates: crd
-			}
-		}))
+	const res = shape.coordinates.map(crd => ({
+		type: 'Feature',
+		properties: {},
+		geometry: {
+			type: 'Point',
+			coordinates: crd
+		}
+	}))
 
-		if (Array.isArray(p.ppLocRefL)) {
-			for (let ref of p.ppLocRefL) {
-				const p = res[ref.ppIdx]
-				if (p && ref.location) p.properties = ref.location
-			}
-
-			// Often there is one more point right next to each point at a station.
-			// We filter them here if they are < 5m from each other.
-			for (let i = 1; i < res.length; i++) {
-				const p1 = res[i - 1].geometry.coordinates
-				const p2 = res[i].geometry.coordinates
-				const d = distance(p1[1], p1[0], p2[1], p2[0])
-				if (d >= .005) continue
-				const l1 = Object.keys(res[i - 1].properties).length
-				const l2 = Object.keys(res[i].properties).length
-				if (l1 === 0 && l2 > 0) res.splice(i - 1, 1)
-				else if (l2 === 0 && l1 > 0) res.splice(i, 1)
-			}
+	if (Array.isArray(p.ppLocRefL)) {
+		for (let ref of p.ppLocRefL) {
+			const p = res[ref.ppIdx]
+			if (p && ref.location) p.properties = ref.location
 		}
 
-		return {
-			type: 'FeatureCollection',
-			features: res
+		// Often there is one more point right next to each point at a station.
+		// We filter them here if they are < 5m from each other.
+		for (let i = 1; i < res.length; i++) {
+			const p1 = res[i - 1].geometry.coordinates
+			const p2 = res[i].geometry.coordinates
+			const d = distance(p1[1], p1[0], p2[1], p2[0])
+			if (d >= .005) continue
+			const l1 = Object.keys(res[i - 1].properties).length
+			const l2 = Object.keys(res[i].properties).length
+			if (l1 === 0 && l2 > 0) res.splice(i - 1, 1)
+			else if (l2 === 0 && l1 > 0) res.splice(i, 1)
 		}
 	}
-	return parsePolyline
+
+	return {
+		type: 'FeatureCollection',
+		features: res
+	}
 }
 
-module.exports = createParsePolyline
+module.exports = parsePolyline

--- a/parse/products-bitmask.js
+++ b/parse/products-bitmask.js
@@ -1,22 +1,17 @@
 'use strict'
 
-const createParseBitmask = (profile) => {
-	const defaultProducts = {}
-	for (let product of profile.products) defaultProducts[product.id] = false
+const parseBitmask = ({profile}, bitmask) => {
+	const res = {}
+	for (let product of profile.products) res[product.id] = false
 
-	const parseBitmask = (bitmask) => {
-		const res = Object.assign({}, defaultProducts)
+	const bits = bitmask.toString(2).split('').map(i => parseInt(i)).reverse()
+	for (let i = 0; i < bits.length; i++) {
+		if (!bits[i]) continue // ignore `0`
 
-		const bits = bitmask.toString(2).split('').map(i => parseInt(i)).reverse()
-		for (let i = 0; i < bits.length; i++) {
-			if (!bits[i]) continue // ignore `0`
-
-			const product = profile.products.find(p => p.bitmasks.includes(Math.pow(2, i)))
-			if (product) res[product.id] = true
-		}
-		return res
+		const product = profile.products.find(p => p.bitmasks.includes(Math.pow(2, i)))
+		if (product) res[product.id] = true
 	}
-	return parseBitmask
+	return res
 }
 
-module.exports = createParseBitmask
+module.exports = parseBitmask

--- a/parse/stopover.js
+++ b/parse/stopover.js
@@ -4,48 +4,46 @@ const parseWhen = require('./when')
 const parsePlatform = require('./platform')
 const findRemarks = require('./find-remarks')
 
-const createParseStopover = (profile, opt, data, date) => {
-	const parseStopover = (st) => {
-		const arr = parseWhen(profile, date, st.aTimeS, st.aTimeR, st.aTZOffset, st.aCncl)
-		const arrPl = parsePlatform(profile, st.aPlatfS, st.aPlatfR, st.aCncl)
-		const dep = parseWhen(profile, date, st.dTimeS, st.dTimeR, st.dTZOffset, st.dCncl)
-		const depPl = parsePlatform(profile, st.dPlatfS, st.dPlatfR, st.dCncl)
+const parseStopover = (ctx, st, date) => { // st = raw stopover
+	const {profile, opt} = ctx
 
-		const res = {
-			stop: st.location || null,
-			arrival: arr.when,
-			plannedArrival: arr.plannedWhen,
-			arrivalDelay: arr.delay,
-			arrivalPlatform: arrPl.platform,
-			plannedArrivalPlatform: arrPl.plannedPlatform,
-			departure: dep.when,
-			plannedDeparture: dep.plannedWhen,
-			departureDelay: dep.delay,
-			departurePlatform: depPl.platform,
-			plannedDeparturePlatform: depPl.plannedPlatform
-		}
+	const arr = profile.parseWhen(ctx, date, st.aTimeS, st.aTimeR, st.aTZOffset, st.aCncl)
+	const arrPl = profile.parsePlatform(ctx, st.aPlatfS, st.aPlatfR, st.aCncl)
+	const dep = profile.parseWhen(ctx, date, st.dTimeS, st.dTimeR, st.dTZOffset, st.dCncl)
+	const depPl = profile.parsePlatform(ctx, st.dPlatfS, st.dPlatfR, st.dCncl)
 
-		if (arr.prognosedWhen) res.prognosedArrival = arr.prognosedWhen
-		if (arrPl.prognosedPlatform) res.prognosedArrivalPlatform = arrPl.prognosedPlatform
-		if (dep.prognosedWhen) res.prognosedDeparture = dep.prognosedWhen
-		if (depPl.prognosedPlatform) res.prognosedDeparturePlatform = depPl.prognosedPlatform
-
-		// mark stations the train passes without stopping
-		if(st.dInS === false && st.aOutS === false) res.passBy = true
-
-		if (st.aCncl || st.dCncl) {
-			res.cancelled = true
-			Object.defineProperty(res, 'canceled', {value: true})
-		}
-
-		if (opt.remarks && Array.isArray(st.msgL)) {
-			res.remarks = findRemarks(st.msgL).map(([remark]) => remark)
-		}
-
-		return res
+	const res = {
+		stop: st.location || null,
+		arrival: arr.when,
+		plannedArrival: arr.plannedWhen,
+		arrivalDelay: arr.delay,
+		arrivalPlatform: arrPl.platform,
+		plannedArrivalPlatform: arrPl.plannedPlatform,
+		departure: dep.when,
+		plannedDeparture: dep.plannedWhen,
+		departureDelay: dep.delay,
+		departurePlatform: depPl.platform,
+		plannedDeparturePlatform: depPl.plannedPlatform
 	}
 
-	return parseStopover
+	if (arr.prognosedWhen) res.prognosedArrival = arr.prognosedWhen
+	if (arrPl.prognosedPlatform) res.prognosedArrivalPlatform = arrPl.prognosedPlatform
+	if (dep.prognosedWhen) res.prognosedDeparture = dep.prognosedWhen
+	if (depPl.prognosedPlatform) res.prognosedDeparturePlatform = depPl.prognosedPlatform
+
+	// mark stations the train passes without stopping
+	if(st.dInS === false && st.aOutS === false) res.passBy = true
+
+	if (st.aCncl || st.dCncl) {
+		res.cancelled = true
+		Object.defineProperty(res, 'canceled', {value: true})
+	}
+
+	if (opt.remarks && Array.isArray(st.msgL)) {
+		res.remarks = findRemarks(st.msgL).map(([remark]) => remark)
+	}
+
+	return res
 }
 
-module.exports = createParseStopover
+module.exports = parseStopover

--- a/parse/when.js
+++ b/parse/when.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const parseWhen = (profile, date, timeS, timeR, tzOffset, cncl = false) => {
-	const parse = profile.parseDateTime
+const parseWhen = (ctx, date, timeS, timeR, tzOffset, cncl = false) => {
+	const parse = ctx.profile.parseDateTime
 
-	let planned = timeS ? parse(profile, date, timeS, tzOffset, false) : null
-	let prognosed = timeR ? parse(profile, date, timeR, tzOffset, false) : null
+	let planned = timeS ? parse(ctx, date, timeS, tzOffset, false) : null
+	let prognosed = timeR ? parse(ctx, date, timeR, tzOffset, false) : null
 	let delay = null
 
 	if (planned && prognosed) {
-		const tPlanned = parse(profile, date, timeS, tzOffset, true)
-		const tPrognosed = parse(profile, date, timeR, tzOffset, true)
+		const tPlanned = parse(ctx, date, timeS, tzOffset, true)
+		const tPrognosed = parse(ctx, date, timeR, tzOffset, true)
 		delay = Math.round((tPrognosed - tPlanned) / 1000)
 	}
 

--- a/retry.js
+++ b/retry.js
@@ -2,42 +2,36 @@
 
 const retry = require('p-retry')
 
-const _request = require('./lib/request')
-
 const retryDefaults = {
 	retries: 3,
 	factor: 3,
 	minTimeout: 5 * 1000
 }
 
-const withRetrying = (createClient, retryOpts = {}) => {
+const withRetrying = (profile, retryOpts = {}) => {
 	retryOpts = Object.assign({}, retryDefaults, retryOpts)
+	const {request} = profile
 
-	const createRetryingClient = (profile, userAgent, opt = {}) => {
-		const request = 'request' in opt ? opt.request : _request
-
-		const retryingRequest = (profile, userAgent, opt, data) => {
-			const attempt = () => {
-				return request(profile, userAgent, opt, data)
-				.catch((err) => {
-					if (err.isHafasError) throw err // continue
-					if (err.code === 'ENOTFOUND') { // abort
-						const abortErr = new retry.AbortError(err)
-						Object.assign(abortErr, err)
-						throw abortErr
-					}
-					throw err // continue
-				})
-			}
-			return retry(attempt, retryOpts)
+	const retryingRequest = (...args) => {
+		const attempt = () => {
+			return request(...args)
+			.catch((err) => {
+				if (err.isHafasError) throw err // continue
+				if (err.code === 'ENOTFOUND') { // abort
+					const abortErr = new retry.AbortError(err)
+					Object.assign(abortErr, err)
+					throw abortErr
+				}
+				throw err // continue
+			})
 		}
-
-		return createClient(profile, userAgent, {
-			...opt,
-			request: retryingRequest
-		})
+		return retry(attempt, retryOpts)
 	}
-	return createRetryingClient
+
+	return {
+		...profile,
+		request: retryingRequest
+	}
 }
 
 module.exports = withRetrying

--- a/test/bvg-journey.js
+++ b/test/bvg-journey.js
@@ -5,7 +5,7 @@ const tape = require('tape')
 
 const createClient = require('..')
 const rawProfile = require('../p/bvg')
-const raw = require('./fixtures/bvg-journey.json')
+const res = require('./fixtures/bvg-journey.json')
 const expected = require('./fixtures/bvg-journey.js')
 
 const test = tapePromise(tape)
@@ -31,9 +31,9 @@ const opt = {
 }
 
 test('parses a journey correctly (BVG)', (t) => {
-	const common = profile.parseCommon(profile, opt, raw)
-	const parseJourney = profile.parseJourney(profile, opt, common)
-	const journey = parseJourney(common.outConL[0])
+	const common = profile.parseCommon({profile, opt, res})
+	const ctx = {profile, opt, common, res}
+	const journey = profile.parseJourney(ctx, res.outConL[0])
 
 	t.deepEqual(journey, expected)
 	t.end()

--- a/test/bvg-radar.js
+++ b/test/bvg-radar.js
@@ -5,7 +5,7 @@ const tape = require('tape')
 
 const createClient = require('..')
 const rawProfile = require('../p/bvg')
-const raw = require('./fixtures/bvg-radar.json')
+const res = require('./fixtures/bvg-radar.json')
 const expected = require('./fixtures/bvg-radar.js')
 
 const test = tapePromise(tape)
@@ -23,9 +23,9 @@ const opt = {
 }
 
 test('parses a radar() response correctly (BVG)', (t) => {
-	const common = profile.parseCommon(profile, opt, raw)
-	const parseMovement = profile.parseMovement(profile, opt, common)
-	const movements = raw.jnyL.map(parseMovement)
+	const common = profile.parseCommon({profile, opt, res})
+	const ctx = {profile, opt, common, res}
+	const movements = res.jnyL.map(m => profile.parseMovement(ctx, m))
 
 	t.deepEqual(movements, expected)
 	t.end()

--- a/test/format/index.js
+++ b/test/format/index.js
@@ -1,0 +1,3 @@
+'use strict'
+
+require('./products-filter')

--- a/test/format/products-filter.js
+++ b/test/format/products-filter.js
@@ -21,17 +21,16 @@ const products = [
 	},
 ]
 
-const profile = {products}
 const ctx = {
 	common: {},
 	opt: {},
-	profile
+	profile: {products}
 }
 
 test('formatProductsFilter works without customisations', (t) => {
 	const expected = 1 | 2 | 4
 	const filter = {}
-	t.deepEqual(format(profile)(filter), {
+	t.deepEqual(format(ctx, filter), {
 		type: 'PROD',
 		mode: 'INC',
 		value: expected + ''
@@ -40,13 +39,13 @@ test('formatProductsFilter works without customisations', (t) => {
 })
 
 test('formatProductsFilter works with customisations', (t) => {
-	t.equal(+format(profile)({
+	t.equal(+format(ctx, {
 		bus: true
 	}).value, 1 | 2 | 4)
-	t.equal(+format(profile)({
+	t.equal(+format(ctx, {
 		bus: false
 	}).value, 1 | 2)
-	t.equal(+format(profile)({
+	t.equal(+format(ctx, {
 		tram: true
 	}).value, 1 | 2 | 4 | 8 | 32)
 	t.end()

--- a/test/format/products-filter.js
+++ b/test/format/products-filter.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const test = require('tape')
+const format = require('../../format/products-filter')
+
+const products = [
+	{
+		id: 'train',
+		bitmasks: [1, 2],
+		default: true
+	},
+	{
+		id: 'bus',
+		bitmasks: [4],
+		default: true
+	},
+	{
+		id: 'tram',
+		bitmasks: [8, 32],
+		default: false
+	},
+]
+
+const profile = {products}
+const ctx = {
+	common: {},
+	opt: {},
+	profile
+}
+
+test('formatProductsFilter works without customisations', (t) => {
+	const expected = 1 | 2 | 4
+	const filter = {}
+	t.deepEqual(format(profile)(filter), {
+		type: 'PROD',
+		mode: 'INC',
+		value: expected + ''
+	})
+	t.end()
+})
+
+test('formatProductsFilter works with customisations', (t) => {
+	t.equal(+format(profile)({
+		bus: true
+	}).value, 1 | 2 | 4)
+	t.equal(+format(profile)({
+		bus: false
+	}).value, 1 | 2)
+	t.equal(+format(profile)({
+		tram: true
+	}).value, 1 | 2 | 4 | 8 | 32)
+	t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 require('./parse')
+require('./format')
 
 require('./bvg-journey')
 require('./vbb-departures')

--- a/test/parse/date-time.js
+++ b/test/parse/date-time.js
@@ -3,48 +3,53 @@
 const test = require('tape')
 const parse = require('../../parse/date-time')
 
-const profile = {
-	timezone: 'Europe/Berlin',
-	locale: 'de-DE'
+const ctx = {
+	common: {},
+	opt: {},
+	profile: {
+		timezone: 'Europe/Berlin',
+		locale: 'de-DE'
+	}
 }
 
-test('date & time parsing uses profile.timezone', (t) => {
-	const iso = parse({
-		...profile, timezone: 'Europe/Moscow'
-	}, '20190819', '203000', undefined, false)
-	t.equal(iso, '2019-08-19T20:30:00+03:00')
-	t.end()
-})
-
 test('date & time parsing returns a timestamp', (t) => {
-	const iso = parse(profile, '20190819', '203000', undefined, false)
-	const ts = parse(profile, '20190819', '203000', undefined, true)
+	const iso = parse(ctx, '20190819', '203000', undefined, false)
+	const ts = parse(ctx, '20190819', '203000', undefined, true)
 	t.equal(ts, +new Date(iso))
 	t.equal(ts, 1566239400 * 1000)
 	t.end()
 })
 
 test('date & time parsing uses tzOffset', (t) => {
-	const iso = parse(profile, '20190819', '203000', -120, false)
+	const iso = parse(ctx, '20190819', '203000', -120, false)
 	t.equal(iso, '2019-08-19T20:30:00-02:00')
 	t.end()
 })
 
 test('date & time parsing works with day "overflow"', (t) => {
-	const iso = parse(profile, '20190819', '02203000', undefined, false)
+	const iso = parse(ctx, '20190819', '02203000', undefined, false)
 	t.equal(iso, '2019-08-21T20:30:00+02:00')
 	t.end()
 })
 
 // #106
 test('date & time parsing works with day "overflow" & tzOffset', (t) => {
-	const iso = parse(profile, '20190819', '02203000', -120, false)
+	const iso = parse(ctx, '20190819', '02203000', -120, false)
 	t.equal(iso, '2019-08-21T20:30:00-02:00')
 	t.end()
 })
 
 test('date & time parsing works with summer & winter time', (t) => {
-	const iso = parse(profile, '20190219', '203000', undefined, false)
+	const iso = parse(ctx, '20190219', '203000', undefined, false)
 	t.equal(iso, '2019-02-19T20:30:00+01:00')
+	t.end()
+})
+
+test('date & time parsing uses profile.timezone', (t) => {
+	const iso = parse({
+		...ctx,
+		profile: {...ctx.profile, timezone: 'Europe/Moscow'}
+	}, '20190819', '203000', undefined, false)
+	t.equal(iso, '2019-08-19T20:30:00+03:00')
 	t.end()
 })

--- a/test/parse/hint.js
+++ b/test/parse/hint.js
@@ -3,7 +3,11 @@
 const test = require('tape')
 const parse = require('../../parse/hint')
 
-const profile = {}
+const ctx = {
+	data: {},
+	opt: {},
+	profile: {}
+}
 
 test('parses hints correctly', (t) => {
 	const input = {
@@ -18,20 +22,20 @@ test('parses hints correctly', (t) => {
 		text: 'some text'
 	}
 
-	t.deepEqual(parse(profile, input), expected)
-	t.deepEqual(parse(profile, {
+	t.deepEqual(parse(ctx, input), expected)
+	t.deepEqual(parse(ctx, {
 		...input, type: 'I'
 	}), expected)
 
 	// alternative trip
-	t.deepEqual(parse(profile, {
+	t.deepEqual(parse(ctx, {
 		...input, type: 'L', jid: 'trip id'
 	}), {
 		...expected, type: 'status', code: 'alternative-trip', tripId: 'trip id'
 	})
 
 	// type: M
-	t.deepEqual(parse(profile, {
+	t.deepEqual(parse(ctx, {
 		...input, type: 'M', txtS: 'some summary'
 	}), {
 		...expected, type: 'status', summary: 'some summary'
@@ -39,18 +43,18 @@ test('parses hints correctly', (t) => {
 
 	// type: D
 	for (const type of ['D', 'U', 'R', 'N', 'Y']) {
-		t.deepEqual(parse(profile, {...input, type}), {
+		t.deepEqual(parse(ctx, {...input, type}), {
 			...expected, type: 'status'
 		})
 	}
 
 	// .code via .icon
-	t.deepEqual(parse(profile, {
+	t.deepEqual(parse(ctx, {
 		...input, code: null, icon: {type: 'cancel'}
 	}), {...expected, code: 'cancelled'})
 
 	// invalid
-	t.equal(parse(profile, {...input, type: 'X'}), null)
+	t.equal(parse(ctx, {...input, type: 'X'}), null)
 
 	t.end()
 })

--- a/test/parse/icon.js
+++ b/test/parse/icon.js
@@ -3,14 +3,18 @@
 const test = require('tape')
 const parse = require('../../parse/icon')
 
-test('parses icons correctly', (t) => {
-	const profile = {}
+const ctx = {
+	data: {},
+	opt: {},
+	profile: {}
+}
 
+test('parses icons correctly', (t) => {
 	const text = {
 		"res": "BVG",
 		"text": "Berliner Verkehrsbetriebe"
 	}
-	t.deepEqual(parse(profile, text), {
+	t.deepEqual(parse(ctx, text), {
 		type: 'BVG',
 		title: 'Berliner Verkehrsbetriebe'
 	})
@@ -19,7 +23,7 @@ test('parses icons correctly', (t) => {
 		"res": "PROD_BUS",
 		"txtS": "18"
 	}
-	t.deepEqual(parse(profile, txtS), {
+	t.deepEqual(parse(ctx, txtS), {
 		type: 'PROD_BUS',
 		title: '18'
 	})
@@ -28,7 +32,7 @@ test('parses icons correctly', (t) => {
 		"res": "RBB",
 		"txt": "Regionalbus Braunschweig GmbH"
 	}
-	t.deepEqual(parse(profile, txt), {
+	t.deepEqual(parse(ctx, txt), {
 		type: 'RBB',
 		title: 'Regionalbus Braunschweig GmbH'
 	})
@@ -36,7 +40,7 @@ test('parses icons correctly', (t) => {
 	const noText = {
 		"res": "attr_bike_r"
 	}
-	t.deepEqual(parse(profile, noText), {
+	t.deepEqual(parse(ctx, noText), {
 		type: 'attr_bike_r',
 		title: null
 	})
@@ -56,7 +60,7 @@ test('parses icons correctly', (t) => {
 			"a": 255
 		}
 	}
-	t.deepEqual(parse(profile, withColor), {
+	t.deepEqual(parse(ctx, withColor), {
 		type: 'prod_sub_t',
 		title: null,
 		fgColor: {r: 255, g: 255, b: 255, a: 255},

--- a/test/parse/line.js
+++ b/test/parse/line.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tape')
-const parser = require('../../parse/line')
+const parse = require('../../parse/line')
 
 const profile = {
 	products: [
@@ -10,8 +10,11 @@ const profile = {
 		{id: 'bus', bitmasks: [4, 8]}
 	]
 }
-const opt = {}
-const parse = parser(profile, opt, {})
+const ctx = {
+	data: {},
+	opt: {},
+	profile
+}
 
 test('parses lines correctly', (t) => {
 	const input = {
@@ -29,23 +32,23 @@ test('parses lines correctly', (t) => {
 		public: true
 	}
 
-	t.deepEqual(parse(input), expected)
+	t.deepEqual(parse(ctx, input), expected)
 
-	t.deepEqual(parse({
+	t.deepEqual(parse(ctx, {
 		...input, line: null, addName: input.line
 	}), expected)
-	t.deepEqual(parse({
+	t.deepEqual(parse(ctx, {
 		...input, line: null, name: input.line
 	}), expected)
 
 	// no prodCtx.lineId
-	t.deepEqual(parse({
+	t.deepEqual(parse(ctx, {
 		...input, prodCtx: {...input.prodCtx, lineId: null}
 	}), {
 		...expected, id: 'foo-line'
 	})
 	// no prodCtx
-	t.deepEqual(parse({
+	t.deepEqual(parse(ctx, {
 		...input, prodCtx: undefined
 	}), {
 		...expected, id: 'foo-line', fahrtNr: null

--- a/test/parse/location.js
+++ b/test/parse/location.js
@@ -5,11 +5,16 @@ const omit = require('lodash/omit')
 const parse = require('../../parse/location')
 
 const profile = {
-	parseStationName: name => name.toLowerCase(),
-	parseProducts: bitmask => [bitmask]
+	parseStationName: (_, name) => name.toLowerCase(),
+	parseProductsBitmask: (_, bitmask) => [bitmask]
 }
-const opt = {
-	linesOfStops: false
+
+const ctx = {
+	data: {},
+	opt: {
+		linesOfStops: false
+	},
+	profile
 }
 
 test('parses an address correctly', (t) => {
@@ -20,7 +25,7 @@ test('parses an address correctly', (t) => {
 		crd: {x: 13418027, y: 52515503}
 	}
 
-	const address = parse(profile, opt, null, input)
+	const address = parse(ctx, input)
 	t.deepEqual(address, {
 		type: 'location',
 		id: 'some id',
@@ -40,7 +45,7 @@ test('parses a POI correctly', (t) => {
 		crd: {x: 13418027, y: 52515503}
 	}
 
-	const poi = parse(profile, opt, null, input)
+	const poi = parse(ctx, input)
 	t.deepEqual(poi, {
 		type: 'location',
 		poi: true,
@@ -50,10 +55,10 @@ test('parses a POI correctly', (t) => {
 		longitude: 13.418027
 	})
 
-	const withExtId = parse(profile, opt, null, {...input, extId: 'some ext id'})
+	const withExtId = parse(ctx, {...input, extId: 'some ext id'})
 	t.equal(withExtId.id, 'some ext id')
 
-	const withLeadingZero = parse(profile, opt, null, {...input, extId: '00some ext id'})
+	const withLeadingZero = parse(ctx, {...input, extId: '00some ext id'})
 	t.equal(withLeadingZero.id, 'some ext id')
 
 	t.end()
@@ -68,7 +73,7 @@ test('parses a stop correctly', (t) => {
 		pCls: 123
 	}
 
-	const stop = parse(profile, opt, null, input)
+	const stop = parse(ctx, input)
 	t.deepEqual(stop, {
 		type: 'stop',
 		id: 'foo stop',
@@ -82,17 +87,20 @@ test('parses a stop correctly', (t) => {
 		products: [123]
 	})
 
-	const withoutLoc = parse(profile, opt, null, omit(input, ['crd']))
+	const withoutLoc = parse(ctx, omit(input, ['crd']))
 	t.equal(withoutLoc.location, null)
 
-	const mainMast = parse(profile, opt, null, {...input, isMainMast: true})
+	const mainMast = parse(ctx, {...input, isMainMast: true})
 	t.equal(mainMast.type, 'station')
 
-	const meta = parse(profile, opt, null, {...input, meta: 1})
+	const meta = parse(ctx, {...input, meta: 1})
 	t.equal(meta.isMeta, true)
 
 	const lineA = {id: 'a'}
-	const withLines = parse(profile, {...opt, linesOfStops: true}, null, {
+	const withLines = parse({
+		...ctx,
+		opt: {...ctx.opt, linesOfStops: true}
+	}, {
 		...input, lines: [lineA]
 	})
 	t.deepEqual(withLines.lines, [lineA])

--- a/test/parse/operator.js
+++ b/test/parse/operator.js
@@ -3,16 +3,19 @@
 const test = require('tape')
 const parse = require('../../parse/operator')
 
+const ctx = {
+	data: {},
+	opt: {},
+	profile: {}
+}
 test('parses an operator correctly', (t) => {
-	const profile = {}
-
 	const op = {
 		"name": "Berliner Verkehrsbetriebe",
 		"icoX": 1,
 		"id": "Berliner Verkehrsbetriebe"
 	}
 
-	t.deepEqual(parse(profile, op), {
+	t.deepEqual(parse(ctx, op), {
 		type: 'operator',
 		id: 'berliner-verkehrsbetriebe',
 		name: 'Berliner Verkehrsbetriebe'

--- a/test/parse/warning.js
+++ b/test/parse/warning.js
@@ -4,8 +4,13 @@ const test = require('tape')
 const parse = require('../../parse/warning')
 
 const profile = {
-	parseProducts: bitmask => [bitmask],
+	parseProductsBitmask: (_, bitmask) => [bitmask],
 	parseDateTime: (_, date, time) => date + ':' + time
+}
+const ctx = {
+	data: {},
+	opt: {},
+	profile
 }
 
 test('parses warnings correctly', (t) => {
@@ -27,26 +32,26 @@ test('parses warnings correctly', (t) => {
 		category: 1
 	}
 
-	t.deepEqual(parse(profile, input), expected)
+	t.deepEqual(parse(ctx, input), expected)
 
 	// without basic fields
-	t.deepEqual(parse(profile, {...input, hid: null}), {...expected, id: null})
-	t.deepEqual(parse(profile, {...input, head: null}), {...expected, summary: null})
-	t.deepEqual(parse(profile, {...input, text: null}), {...expected, text: null})
-	t.deepEqual(parse(profile, {...input, cat: null}), {...expected, category: null})
+	t.deepEqual(parse(ctx, {...input, hid: null}), {...expected, id: null})
+	t.deepEqual(parse(ctx, {...input, head: null}), {...expected, summary: null})
+	t.deepEqual(parse(ctx, {...input, text: null}), {...expected, text: null})
+	t.deepEqual(parse(ctx, {...input, cat: null}), {...expected, category: null})
 
 	// without icon
-	t.deepEqual(parse(profile, {...input, icon: null}), {
+	t.deepEqual(parse(ctx, {...input, icon: null}), {
 		...expected, type: 'warning', icon: null
 	})
 
 	// with products
-	t.deepEqual(parse(profile, {...input, prod: 123}), {
+	t.deepEqual(parse(ctx, {...input, prod: 123}), {
 		...expected, products: [123]
 	})
 
 	// validFrom, validUntil, modified
-	t.deepEqual(parse(profile, {
+	t.deepEqual(parse(ctx, {
 		...input,
 		sDate: '20190101', sTime: '094020',
 		eDate: '20190101', eTime: '114020',

--- a/test/parse/when.js
+++ b/test/parse/when.js
@@ -4,10 +4,15 @@ const test = require('tape')
 const parse = require('../../parse/when')
 
 const profile = {
-	parseDateTime: (profile, date, time, tzOffset, timestamp = false) => {
+	parseDateTime: ({profile}, date, time, tzOffset, timestamp = false) => {
 		if (timestamp) return ((date + '' + time) - tzOffset * 60) * 1000
 		return date + ':' + time
 	}
+}
+const ctx = {
+	data: {},
+	opt: {},
+	profile
 }
 
 test('parseWhen works correctly', (t) => {
@@ -21,15 +26,15 @@ test('parseWhen works correctly', (t) => {
 		delay: 130 // seconds
 	}
 
-	t.deepEqual(parse(profile, date, timeS, timeR, tzOffset), expected)
+	t.deepEqual(parse(ctx, date, timeS, timeR, tzOffset), expected)
 
 	// no realtime data
-	t.deepEqual(parse(profile, date, timeS, null, tzOffset), {
+	t.deepEqual(parse(ctx, date, timeS, null, tzOffset), {
 		...expected, when: expected.plannedWhen, delay: null
 	})
 
 	// cancelled
-	t.deepEqual(parse(profile, date, timeS, timeR, tzOffset, true), {
+	t.deepEqual(parse(ctx, date, timeS, timeR, tzOffset, true), {
 		...expected,
 		when: null,
 		prognosedWhen: expected.when

--- a/test/retry.js
+++ b/test/retry.js
@@ -2,8 +2,8 @@
 
 const test = require('tape')
 
-const withRetrying = require('../retry')
 const createClient = require('..')
+const withRetrying = require('../retry')
 const vbbProfile = require('../p/vbb')
 
 const userAgent = 'public-transport/hafas-client:test'
@@ -12,7 +12,7 @@ const spichernstr = '900000042101'
 test('withRetrying works', (t) => {
 	// for the first 3 calls, return different kinds of errors
 	let calls = 0
-	const failingRequest = (profile, userAgent, opt, data) => {
+	const failingRequest = async (ctx, userAgent, reqData) => {
 		calls++
 		if (calls === 1) {
 			const err = new Error('HAFAS error')
@@ -25,18 +25,22 @@ test('withRetrying works', (t) => {
 			return Promise.reject(err)
 		}
 		if (calls < 4) return Promise.reject(new Error('generic error'))
-		return Promise.resolve([])
+		return {
+			res: [],
+			common: {}
+		}
 	}
 
-	const createRetryingClient = withRetrying(createClient, {
+	const profile = withRetrying({
+		...vbbProfile,
+		request: failingRequest
+	}, {
 		retries: 3,
 		minTimeout: 100,
 		factor: 2,
 		randomize: false
 	})
-	const client = createRetryingClient(vbbProfile, userAgent, {
-		request: failingRequest
-	})
+	const client = createClient(profile, userAgent)
 
 	t.plan(1 + 4)
 	client.departures(spichernstr, {duration: 1})

--- a/test/throttle.js
+++ b/test/throttle.js
@@ -3,8 +3,8 @@
 const tapePromise = require('tape-promise').default
 const tape = require('tape')
 
-const withThrottling = require('../throttle')
 const createClient = require('..')
+const withThrottling = require('../throttle')
 const vbbProfile = require('../p/vbb')
 const depsRes = require('./fixtures/vbb-departures.json')
 
@@ -14,10 +14,8 @@ const spichernstr = '900000042101'
 const test = tapePromise(tape)
 
 test('withThrottling works', async (t) => {
-	const ctx = {profile: vbbProfile, opt: {}}
-
 	let calls = 0
-	const mockedRequest = async (ctx, _, reqData) => {
+	const mockedRequest = async (ctx, userAgent, reqData) => {
 		calls++
 		return {
 			res: depsRes,
@@ -25,8 +23,11 @@ test('withThrottling works', async (t) => {
 		}
 	}
 
-	const createThrottledClient = withThrottling(createClient, 2, 1000)
-	const client = createThrottledClient(vbbProfile, ua, mockedRequest)
+	const profile = withThrottling({
+		...vbbProfile,
+		request: mockedRequest
+	}, 2, 1000)
+	const client = createClient(profile, ua)
 
 	t.plan(3)
 	for (let i = 0; i < 10; i++) {

--- a/test/throttle.js
+++ b/test/throttle.js
@@ -12,9 +12,9 @@ const spichernstr = '900000042101'
 // todo: mock request()
 test('withThrottling works', (t) => {
 	let calls = 0
-	const transformReqBody = (body) => {
+	const transformReqBody = (ctx, body) => {
 		calls++
-		return vbbProfile.transformReqBody(body)
+		return vbbProfile.transformReqBody(ctx, body)
 	}
 	const mockProfile = Object.assign({}, vbbProfile, {transformReqBody})
 

--- a/test/vbb-departures.js
+++ b/test/vbb-departures.js
@@ -5,7 +5,7 @@ const tape = require('tape')
 
 const createClient = require('..')
 const rawProfile = require('../p/vbb')
-const raw = require('./fixtures/vbb-departures.json')
+const res = require('./fixtures/vbb-departures.json')
 const expected = require('./fixtures/vbb-departures.js')
 
 const test = tapePromise(tape)
@@ -24,9 +24,9 @@ const opt = {
 }
 
 test('parses a departure correctly (VBB)', (t) => {
-	const common = profile.parseCommon(profile, opt, raw)
-	const parseDeparture = profile.parseDeparture(profile, opt, common)
-	const departures = raw.jnyL.map(parseDeparture)
+	const common = profile.parseCommon({profile, opt, res})
+	const ctx = {profile, opt, common, res}
+	const departures = res.jnyL.map(d => profile.parseDeparture(ctx, d))
 
 	t.deepEqual(departures, expected)
 	t.end()

--- a/throttle.js
+++ b/throttle.js
@@ -2,20 +2,13 @@
 
 const throttle = require('p-throttle')
 
-const _request = require('./lib/request')
+const withThrottling = (profile, limit = 5, interval = 1000) => {
+	const {request} = profile
 
-const withThrottling = (createClient, limit = 5, interval = 1000) => {
-	const createThrottledClient = (profile, userAgent, opt = {}) => {
-		const request = 'request' in opt ? opt.request : _request
-
-		const throttledRequest = throttle(request, limit, interval)
-
-		return createClient(profile, userAgent, {
-			...opt,
-			request: throttledRequest
-		})
+	return {
+		...profile,
+		request: throttle(request, limit, interval)
 	}
-	return createThrottledClient
 }
 
 module.exports = withThrottling


### PR DESCRIPTION
This PR

- changes the code to always access `request()` & `formatProductsFilter()` via `profile`, so that people can pass in custom implementations for these.
- changes the signature of parse fns from `(profile, opt, data) => (rawData) => …` to `(ctx) => (rawData) => …`, with `ctx` looking like `{profile, opt, res, common}`.
- generates the request JSON via `profile.formatStopReq()`, `profile.formatTripReq()`, etc to allow for customizations.
- changes `retry.js` and `throttle.js` to work by wrapping `profile` instead of `createClient`.