### PR TITLE
parse 'Q' hints

### DIFF
--- a/parse/hint.js
+++ b/parse/hint.js
@@ -14,13 +14,6 @@ const codesByIcon = Object.assign(Object.create(null), {
 // ]
 const parseHint = (profile, h, icons) => {
 	// todo: C
-	// todo:
-	// { type: 'Q',
-	//   code: '',
-	//   icoX: 11,
-	//   txtN:
-	//    'RE  3132: Berlin Zoologischer Garten - Brandenburg Hbf: Information. A railway carriage is missing',
-	//   sIdx: 4 }
 
 	const text = h.txtN && h.txtN.trim() || ''
 	const icon = 'number' === typeof h.icoX && icons[h.icoX] || null
@@ -51,7 +44,10 @@ const parseHint = (profile, h, icons) => {
 		}
 	}
 
-	if (h.type === 'D' || h.type === 'U' || h.type === 'R' || h.type === 'N' || h.type === 'Y') {
+	if (
+		h.type === 'D' || h.type === 'U' || h.type === 'R' || h.type === 'N' ||
+		h.type === 'Y' || h.type === 'Q'
+	) {
 		// todo: how can we identify the individual types?
 		// todo: does `D` mean "disturbance"?
 		return {


### PR DESCRIPTION
Parse 'Q' hints. They seem to contain changes to the features of a train.

Some examples:
```
{"type":"Q","code":"","icoX":5,"txtN":"RE 10618: Düsseldorf Hbf - Neuss Hbf: Information. Heute: Mehrzweckabteil hinten","sIdx":0}
{"type":"Q","code":"","icoX":7,"txtN":"RE 10657: Köln/Bonn Flughafen - Duisburg Hbf: Information. Keine behindertengerechte Einrichtung","sIdx":0}
{"type":"Q","code":"","icoX":8,"txtN":"RE 19927: Stuttgart Hbf - Winnenden: Information. Störung fahrzeuggebundene Einstiegshilfe","sIdx":0}
{"type":"Q","code":"","icoX":6,"txtN":"S      1: Hilden Süd - Düsseldorf Hbf: Information. Ein Wagen fehlt","sIdx":0}
```