### PR TITLE
add basic linter setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,8 +14,6 @@
         "ecmaVersion": 2018
     },
     "rules": {
-        "no-irregular-whitespace": "off",
-        "no-mixed-spaces-and-tabs": "off",
         "no-unused-vars": [
             "error",
             {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+    "env": {
+        "commonjs": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "ignorePatterns": ["node_modules", "test", "*example.js"],
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+        "no-irregular-whitespace": "off",
+        "no-mixed-spaces-and-tabs": "off",
+        "no-unused-vars": [
+            "error",
+            {
+                "vars": "all",
+                "args": "none",
+                "ignoreRestSiblings": false
+            }
+        ]
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ node_js:
   - 'lts/*'
   - '10'
 cache: npm
-script: npm run lint && npm test
+script:
+  - npm run lint
+  - npm test
 jobs:
   include:
     - name: e2e-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - 'lts/*'
   - '10'
 cache: npm
-script: npm test
+script: npm run lint && npm test
 jobs:
   include:
     - name: e2e-test

--- a/format/refresh-journey-req.js
+++ b/format/refresh-journey-req.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const formatRefreshJourneyReq = (ctx, refreshToken) => {
+	// eslint-disable-next-line no-unused-vars
 	const {profile, opt} = ctx
 
 	return {

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		}
 
 		opt = Object.assign({
-			results: null, // number of journeys – `null` means "whatever HAFAS returns"
+			results: null, // number of journeys – `null` means "whatever HAFAS returns"
 			via: null, // let journeys pass this station?
 			stopovers: false, // return stations on the way?
 			transfers: -1, // maximum of 5 transfers

--- a/p/oebb/index.js
+++ b/p/oebb/index.js
@@ -49,11 +49,8 @@ const fixMovement = ({parsed}, m) => {
 	// filter out POIs
 	// todo: make use of them, as some of them specify fare zones
 	parsed.nextStopovers = parsed.nextStopovers.filter(st => {
-		const s = st.stop || {}
-		if (s.station) {
-			s = s.station
-			if (s.station.type === 'stop' || s.station.type === 'station') return true
-		}
+		let s = st.stop || {}
+		if (s.station) s = s.station
 		return s.type === 'stop' || s.type === 'station'
 	})
 	parsed.frames = parsed.frames.filter((f) => {

--- a/p/vsn/index.js
+++ b/p/vsn/index.js
@@ -12,6 +12,7 @@ const transformReqBody = (ctx, body) => {
 }
 
 const formatRefreshJourneyReq = (ctx, refreshToken) => {
+	// eslint-disable-next-line no-unused-vars
 	const {profile, opt} = ctx
 
 	return {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 	},
 	"devDependencies": {
 		"db-stations": "^3.0.0",
+		"eslint": "^6.8.0",
 		"is-coordinates": "^2.0.2",
 		"is-roughly-equal": "^0.1.0",
 		"tap-spec": "^5.0.0",
@@ -67,6 +68,7 @@
 	},
 	"scripts": {
 		"e2e-test": "env NODE_ENV=dev node test/e2e/index.js | tap-spec",
+		"lint": "eslint .",
 		"test": "env NODE_ENV=dev node test/index.js | tap-spec",
 		"prepublishOnly": "npm test && npm run e2e-test"
 	}

--- a/parse/arrival-or-departure.js
+++ b/parse/arrival-or-departure.js
@@ -44,14 +44,14 @@ const createParseArrOrDep = (prefix) => {
 			]).map(([remark]) => remark)
 		}
 
-   		if (opt.stopovers && Array.isArray(d.stopL)) {
-  			// Filter stations the train passes without stopping, as this doesn't comply with FPTF (yet).
-  			const stopovers = d.stopL
-  			.map(st => profile.parseStopover(ctx, st, d.date))
-  			.filter(st => !st.passBy)
-  			if (prefix === ARRIVAL) res.previousStopovers = stopovers
+		if (opt.stopovers && Array.isArray(d.stopL)) {
+			// Filter stations the train passes without stopping, as this doesn't comply with FPTF (yet).
+			const stopovers = d.stopL
+			.map(st => profile.parseStopover(ctx, st, d.date))
+			.filter(st => !st.passBy)
+			if (prefix === ARRIVAL) res.previousStopovers = stopovers
 			else if (prefix === DEPARTURE) res.nextStopovers = stopovers
-  		}
+		}
 
 		return res
 	}

--- a/parse/arrival-or-departure.js
+++ b/parse/arrival-or-departure.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const parseWhen = require('./when')
-const parsePlatform = require('./platform')
 const findRemarks = require('./find-remarks')
 
 const ARRIVAL = 'a'

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const parseWhen = require('./when')
-const parsePlatform = require('./platform')
 const findRemarks = require('./find-remarks')
 
 const clone = obj => Object.assign({}, obj)

--- a/parse/location.js
+++ b/parse/location.js
@@ -27,7 +27,7 @@ const parseLocation = (ctx, l) => {
 		const stop = {
 			type: l.isMainMast ? 'station' : 'stop',
 			id: res.id,
-			name: l.name || id.O ? profile.parseStationName(ctx, l.name || id.O) : null,
+			name: l.name || lid.O ? profile.parseStationName(ctx, l.name || lid.O) : null,
 			location: 'number' === typeof res.latitude ? res : null // todo: remove `.id`
 		}
 

--- a/parse/stopover.js
+++ b/parse/stopover.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const parseWhen = require('./when')
-const parsePlatform = require('./platform')
 const findRemarks = require('./find-remarks')
 
 const parseStopover = (ctx, st, date) => { // st = raw stopover


### PR DESCRIPTION
I propose to add a very simple and unopinionated linter setup to the project to catch the most basic errors, like undefined- or unused variables.

Note that this setup excludes all tests and example files. IMHO this makes sense since things like unused variables are most likely intentional in tests while being accidental in the normal code base.

Also note that while I disabled the `no-irregular-whitespace` and `no-mixed-spaces-and-tabs` rules, it might actually make sense to enable them.

What's your opinion on this?

Also, to determine if this setup adds any value, here's the current linter error log for `master`:

> …/hafas-client/format/refresh-journey-req.js
>   4:9  error  'profile' is assigned a value but never used (no-unused-vars)
> 
> …/hafas-client/p/oebb/index.js
>   54:4  error  's' is constant (no-const-assign)
> 
> …/hafas-client/p/vsn/index.js
>   15:9  error  'profile' is assigned a value but never used (no-unused-vars)
> 
> …/hafas-client/parse/arrival-or-departure.js
>   3:7  error  'parseWhen' is assigned a value but never used     (no-unused-vars)
>   4:7  error  'parsePlatform' is assigned a value but never used (no-unused-vars)
> 
> …/hafas-client/parse/journey-leg.js
>   3:7  error  'parseWhen' is assigned a value but never used     (no-unused-vars)
>   4:7  error  'parsePlatform' is assigned a value but never used (no-unused-vars)
> 
> …/hafas-client/parse/location.js
>   30:20  error  'id' is not defined (no-undef)
>   30:67  error  'id' is not defined (no-undef)
> 
> …/hafas-client/parse/stopover.js
>   3:7  error  'parseWhen' is assigned a value but never used     (no-unused-vars)
>   4:7  error  'parsePlatform' is assigned a value but never used (no-unused-vars)
> 
> ✖ 11 problems (11 errors, 0 warnings)