### PR TITLE
parse line.adminCode

### DIFF
--- a/parse/line.js
+++ b/parse/line.js
@@ -21,6 +21,10 @@ const parseLine = ({profile}, p) => {
 	// todo: what is p.number?
 	// todo: what is p.prodCtx.catCode?
 
+	if (p.prodCtx && 'string' === typeof p.prodCtx.admin) {
+		res.adminCode = p.prodCtx.admin.replace(/-+$/, '')
+	}
+
 	if ('cls' in p) {
 		// todo: use profile.products.find() for this
 		const byBitmask = []

--- a/test/fixtures/bvg-journey.js
+++ b/test/fixtures/bvg-journey.js
@@ -702,6 +702,7 @@ module.exports = {
 				id: 's-bahn-berlin-gmbh',
 				name: 'S-Bahn Berlin GmbH'
 			},
+			adminCode: 'DBS',
 			symbol: 'S',
 			nr: 2,
 			metro: false,

--- a/test/fixtures/vbb-departures.js
+++ b/test/fixtures/vbb-departures.js
@@ -191,6 +191,7 @@ module.exports = [
 			fahrtNr: '19869',
 			name: 'U8',
 			public: true,
+			adminCode: 'BVU',
 			mode: 'train',
 			product: 'subway',
 			operator: {
@@ -854,6 +855,7 @@ module.exports = [
 			fahrtNr: '19453',
 			name: 'U8',
 			public: true,
+			adminCode: 'BVU',
 			mode: 'train',
 			product: 'subway',
 			operator: {
@@ -1612,6 +1614,7 @@ module.exports = [
 			fahrtNr: '27739',
 			name: 'S9',
 			public: true,
+			adminCode: 'DBS',
 			mode: 'train',
 			product: 'suburban',
 			operator: {


### PR DESCRIPTION
The admin code is often helpful to distinguish lines that can't be distinguished by their `operator.id` (#10).

Not sure if `adminCode` is a good field name, because we don't know the exact semantics of it yet.