### PR TITLE
Fix platform parsing with some profiles

### DIFF
--- a/parse/arrival-or-departure.js
+++ b/parse/arrival-or-departure.js
@@ -19,8 +19,8 @@ const createParseArrOrDep = (prefix) => {
 		const tPrognosed = d.stbStop[prefix + 'TimeR']
 		const tzOffset = d.stbStop[prefix + 'TZOffset'] || null
 		const cancelled = !!d.stbStop[prefix + 'Cncl']
-		const plPlanned = d.stbStop[prefix + 'PlatfS']
-		const plPrognosed = d.stbStop[prefix + 'PlatfR']
+		const plPlanned = d.stbStop[prefix + 'PlatfS'] || (d.stbStop[prefix + 'PltfS'] !== undefined ? d.stbStop[prefix + 'PltfS'].txt : null)
+		const plPrognosed = d.stbStop[prefix + 'PlatfR'] || (d.stbStop[prefix + 'PltfR'] !== undefined ? d.stbStop[prefix + 'PltfR'].txt : null)
 
 		const res = {
 			tripId: d.jid,

--- a/parse/journey-leg.js
+++ b/parse/journey-leg.js
@@ -89,13 +89,12 @@ const parseJourneyLeg = (ctx, pt, date) => { // pt = raw leg
 		res.tripId = pt.jny.jid
 		res.line = pt.jny.line || null
 		res.direction = pt.jny.dirTxt && profile.parseStationName(ctx, pt.jny.dirTxt) || null
-
-		const arrPl = profile.parsePlatform(ctx, pt.arr.aPlatfS, pt.arr.aPlatfR, pt.arr.aCncl)
+		const arrPl = profile.parsePlatform(ctx, pt.arr.aPlatfS || (pt.arr.aPltfS !== undefined ? pt.arr.aPltfS.txt : null), pt.arr.aPlatfR || (pt.arr.aPltfR !== undefined ? pt.arr.aPltfR.txt : null), pt.arr.aCncl)
 		res.arrivalPlatform = arrPl.platform
 		res.plannedArrivalPlatform = arrPl.plannedPlatform
 		if (arrPl.prognosedPlatform) res.prognosedArrivalPlatform = arrPl.prognosedPlatform
 
-		const depPl = profile.parsePlatform(ctx, pt.dep.dPlatfS, pt.dep.dPlatfR, pt.dep.dCncl)
+		const depPl = profile.parsePlatform(ctx, pt.dep.dPlatfS || (pt.dep.dPltfS !== undefined ? pt.dep.dPltfS.txt : null), pt.dep.dPlatfR || (pt.dep.dPltfR !== undefined ? pt.dep.dPltfR.txt : null), pt.dep.dCncl)
 		res.departurePlatform = depPl.platform
 		res.plannedDeparturePlatform = depPl.plannedPlatform
 		if (depPl.prognosedPlatform) res.prognosedDeparturePlatform = depPl.prognosedPlatform

--- a/parse/stopover.js
+++ b/parse/stopover.js
@@ -6,9 +6,9 @@ const parseStopover = (ctx, st, date) => { // st = raw stopover
 	const {profile, opt} = ctx
 
 	const arr = profile.parseWhen(ctx, date, st.aTimeS, st.aTimeR, st.aTZOffset, st.aCncl)
-	const arrPl = profile.parsePlatform(ctx, st.aPlatfS, st.aPlatfR, st.aCncl)
+	const arrPl = profile.parsePlatform(ctx, st.aPlatfS || (st.aPltfS !== undefined ? st.aPltfS.txt : null), st.aPlatfR || (st.aPltfR !== undefined ? st.aPltfR.txt : null), st.aCncl)
 	const dep = profile.parseWhen(ctx, date, st.dTimeS, st.dTimeR, st.dTZOffset, st.dCncl)
-	const depPl = profile.parsePlatform(ctx, st.dPlatfS, st.dPlatfR, st.dCncl)
+	const depPl = profile.parsePlatform(ctx, st.dPlatfS || (st.dPltfS !== undefined ? st.dPltfS.txt : null), st.dPlatfR || (st.dPltfR !== undefined ? st.dPltfR.txt : null), st.dCncl)
 
 	const res = {
 		stop: st.location || null,


### PR DESCRIPTION
With some profiles hafas-client is unable to parse platforms. This happens with departures/arrival requests, as well as with everywhere where journey-leg or stopover parsing is used. The profiles where I saw this behavior are VSN and ZVV, but I only tried BVG and DB, so there can be more profiles with this issue.

As I'm developer of pyHaFAS I saw that there a multiple ways HaFAS can return the platform. Here is an example for data that hafas-client can accept.
```json
{
  "dPlatfS": "10 A-B",
  "dPlatfR": "9",
}
```

Here are two examples for data returned from the VSN-HaFAS:
```json
{
  "dPltfS": { "type": "PL", "txt": "E" },
}

{
  "dPltfS": { "type": "PL", "txt": "10" },
  "dPltfR": { "type": "U", "txt": "10" }
}
```

I'm not sure what the `type` means, so this PR only covers the `txt` attribute. This attribute is now used as alternative when `XPlatfY` is not available.

I'm open to any recommends on code style (or anything else), since I'm not that experienced with JS.