### PR TITLE
request.js: Use correct HttpsAgent option for localAddress

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -33,7 +33,7 @@ if (proxyAddress) {
 	.map((addr) => {
 		const family = isIP(addr)
 		if (family === 0) throw new Error('invalid local address:' + addr)
-		return new HttpsAgent({addr, family})
+		return new HttpsAgent({localAddress: addr, family})
 	})
 	const pool = roundRobin(agents)
 	getAgent = () => pool.get()


### PR DESCRIPTION
This most likely has been a typo when it was added but according to the [node docs](https://nodejs.org/api/net.html#socketconnectoptions-connectlistener) this field is actually called `localAddress`.

This change also made this locally work again after one of my IPs got blocked by a hafas endpoint.