### PR TITLE
Fix mode for 'ec-ic'

### DIFF
--- a/p/mobil-nrw/products.js
+++ b/p/mobil-nrw/products.js
@@ -67,7 +67,7 @@ const products = [
 	},
 	{
 		id: 'ec-ic',
-		mode: 'ec-ic',
+		mode: 'train',
 		bitmasks: [2],
 		name: 'EC/IC',
 		short: 'EC/IC',


### PR DESCRIPTION
This will fix on error in the integration test.

The tap update was only suitable here, it has nothing to do with the fix.
Update: The tap update has been withdrawn.