### PR TITLE
fixed incorrect parameters in documentation

### DIFF
--- a/docs/lines.md
+++ b/docs/lines.md
@@ -1,4 +1,4 @@
-# `lines([opt])`
+# `lines(query, [opt])`
 
 **Fetches all lines known to the HAFAS endpoint**, e.g. warnings about disruptions, planned construction work, and general notices about the operating situation.
 


### PR DESCRIPTION
I'm not sure how exactly the `query` parameter works exactly, but the source code for `client.lines` requires the parameter `query` and checks if the string is empty.