### PR TITLE
Fix Invalid Client Version Error with BVG API

### DIFF
--- a/p/bvg/base.json
+++ b/p/bvg/base.json
@@ -1,7 +1,7 @@
 {
 	"auth": {
 		"type": "AID",
-		"aid": "YoJ05NartnanEGCj"
+		"aid": "4JX8kx6KDLgSXhHY"
 	},
 	"client": {
 		"type": "IPA",


### PR DESCRIPTION
**Issue:** When running the example or making any request, the BVG API returns an error related to an invalid client version:

```javascript
{
  isHafasError: true,
  code: null,
  isCausedByServer: false,
  hafasCode: 'CLIENTVERSION',
  url: 'https://bvg-apps-ext.hafas.de/bin/mgate.exe?',
  hafasMessage: 'HCI Core: Invalid client version'
}
```

**Resolution:** This issue occurs because the AID (presumably App ID?) value in the `base.json` file is outdated. I have updated the AID to the value currently used in the BVG FahrInfo app on iOS. This change resolves the client version error, allowing requests to be processed correctly.

**Testing:** I have tested the updated AID with multiple requests, and they now work as expected without returning the error.