### PR TITLE
Correct name of BVG

### DIFF
--- a/p/bvg/readme.md
+++ b/p/bvg/readme.md
@@ -1,6 +1,6 @@
 # BVG profile for `hafas-client`
 
-[*Verkehrsverbund Berlin-Brandenburg (BVG)*](https://en.wikipedia.org/wiki/Verkehrsverbund_Berlin-Brandenburg) is the major local transport provider in [Berlin](https://en.wikipedia.org/wiki/Berlin). This profile adds *BVG*-specific customizations to `hafas-client`.
+[*Berliner Verkehrsbetriebe (BVG)*](https://en.wikipedia.org/wiki/Berliner_Verkehrsbetriebe) is the major local transport provider in [Berlin](https://en.wikipedia.org/wiki/Berlin). This profile adds *BVG*-specific customizations to `hafas-client`.
 
 ## Usage
 


### PR DESCRIPTION
The major local transport provider of Berlin is *Berliner Verkehrsbetriebe*, which is often called BVG for its historical name *Berliner Verkehrs-Aktiengesellschaft*.

*Verkehrsverbund Berlin-Brandenburg* is a transport (Verkehr) association (Verbund) of the whole area of both Berlin and Brandeburg. It is a collection of many public transport providers for coordination and the unified fare system. It is not a public transport provider, and it covers much wider area than the state of Berlin.