### PR TITLE
fix(test): rescue BVG radar test with near-future timestamp

### DIFF
--- a/test/e2e/bvg.js
+++ b/test/e2e/bvg.js
@@ -384,16 +384,28 @@ tap.test('stop', async (t) => {
 });
 
 tap.test('radar', async (t) => {
+	// BVG's radar API doesn't return movements for timestamps too far in the
+	// future. For E2E tests, use a near-future timestamp (1 hour). For integration
+	// tests, use the standard `when` to match existing fixtures.
+	const radarWhen = process.env.VCR_MODE && !process.env.VCR_OFF
+		? when
+		: new Date(Date.now() + 60 * 60 * 1000);
+	const radarValidators = createVbbBvgValidators({when: radarWhen});
+	const validateRadar = createValidate(radarValidators.cfg, {
+		movement: radarValidators.validateMovement,
+	});
+
 	const res = await client.radar({
 		north: 52.52411,
 		west: 13.41002,
 		south: 52.51942,
 		east: 13.41709,
 	}, {
-		duration: 5 * 60, when,
+		duration: 5 * 60,
+		when: radarWhen,
 	});
 
-	validate(t, res, 'radarResult', 'res');
+	validateRadar(t, res, 'radarResult', 'res');
 	t.end();
 });
 


### PR DESCRIPTION
BVG's radar API returns empty movements for timestamps too far in the future. The test used createWhen() which calculates "next Monday 10am", causing the API to return no vehicle data.

Solution: Use +1 hour timestamp for E2E tests (live API), keep standard `when` for integration tests (matches existing fixtures):

```js
    const radarWhen = process.env.VCR_MODE && !process.env.VCR_OFF
      ? when
      : new Date(Date.now() + 60 * 60 * 1000);
```