### PR TITLE
fix(test): rescue BVG tests - enable lines and fix cancelled stopovers

### DIFF
--- a/test/e2e/bvg.js
+++ b/test/e2e/bvg.js
@@ -438,7 +438,7 @@ tap.test('remarks', async (t) => {
 	t.end();
 });
 
-tap.skip('lines', async (t) => {
+tap.test('lines', async (t) => {
 	await testLines({
 		test: t,
 		fetchLines: client.lines,

--- a/test/e2e/lib/validators.js
+++ b/test/e2e/lib/validators.js
@@ -251,10 +251,10 @@ const createValidateStopover = (cfg) => {
 			a.strictEqual(typeof s.plannedDeparturePlatform, 'string', msg + 'be a string');
 			a.ok(s.plannedDeparturePlatform, msg + 'not be empty');
 		}
-		if (is(s.plannedArrivalPlatform) && !is(s.arrivalPlatform)) {
+		if (is(s.plannedArrivalPlatform) && !is(s.arrivalPlatform) && !s.cancelled) {
 			a.fail(name + ' has .plannedArrivalPlatform but not .arrivalPlatform');
 		}
-		if (is(s.plannedDeparturePlatform) && !is(s.departurePlatform)) {
+		if (is(s.plannedDeparturePlatform) && !is(s.departurePlatform) && !s.cancelled) {
 			a.fail(name + ' has .plannedDeparturePlatform but not .departurePlatform');
 		}
 

--- a/test/e2e/lib/validators.js
+++ b/test/e2e/lib/validators.js
@@ -12,8 +12,10 @@ const is = val => val !== null && val !== undefined;
 
 const createValidateRealtimeDataUpdatedAt = (cfg) => {
 	const validateRealtimeDataUpdatedAt = (val, rtDataUpdatedAt, name = 'realtimeDataUpdatedAt') => {
-		a.ok(Number.isInteger(rtDataUpdatedAt), name + ' must be an integer');
-		assertValidWhen(rtDataUpdatedAt * 1000, cfg.when, name, 100 * DAY);
+		if (is(rtDataUpdatedAt)) {
+			a.ok(Number.isInteger(rtDataUpdatedAt), name + ' must be an integer');
+			assertValidWhen(rtDataUpdatedAt * 1000, cfg.when, name, 100 * DAY);
+		}
 	};
 	return validateRealtimeDataUpdatedAt;
 };
@@ -114,7 +116,7 @@ const createValidateLine = (cfg) => {
 		defaultValidators.line(val, line, name);
 
 		const msg = name + '.fahrtNr must be ';
-		if (line.fahrtNr !== null) {
+		if (is(line.fahrtNr)) {
 			a.strictEqual(typeof line.fahrtNr, 'string', msg + 'a string');
 			a.ok(line.fahrtNr, msg + ' be empty');
 		}


### PR DESCRIPTION
Fixes remaining BVG E2E tests:

## 1. Lines test - handle undefined optional fields  
Enable previously skipped lines test by fixing validators to properly handle `undefined` (not just `null`) for optional fields like `fahrtNr` and `realtimeDataUpdatedAt`. The lines() API correctly returns `undefined` for these fields since line definitions don't have trip numbers or realtime updates.

Use existing `is()` helper for consistent null/undefined checks throughout validators.

## 2. Via/detour test - cancelled stopovers
Fix platform validation to allow `plannedArrivalPlatform` without `arrivalPlatform` when stopover is cancelled. Cancelled stopovers only have planned values - this is correct API behavior.

